### PR TITLE
feat(generating-flow-diagrams): add AI-agent workflow diagram skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Claude Code aligned.
 
 ## What is in this repository
 
-- [`skills/`](skills/) has 27 first party skills.
+- [`skills/`](skills/) has 28 first party skills.
 - [`docs/`](docs/) has workflow notes, design specs, and writing guidance.
 - [`docs/best-practices/`](docs/best-practices/) is the best place to start if
   you want to edit a skill.
@@ -81,6 +81,9 @@ one for GitHub. The rest are utility skills you can use on their own.
   posting confirmation-gated.
 - [`prompt-structurer`](skills/prompt-structurer/SKILL.md) turns prose prompts
   into structured XML prompts.
+- [`generating-flow-diagrams`](skills/generating-flow-diagrams/SKILL.md) creates
+  or refines Markdown plus Mermaid diagrams for AI-agent workflows with human
+  gates and quality checks.
 - [`review-software-engineer-cv`](skills/review-software-engineer-cv/SKILL.md)
   reviews and tailors a software engineer CV against job postings with realistic,
   evidence-backed recommendations.

--- a/skills/generating-flow-diagrams/SKILL.md
+++ b/skills/generating-flow-diagrams/SKILL.md
@@ -6,13 +6,13 @@ description: "Create or refine Markdown plus Mermaid flow diagrams for AI-agent 
 # Generating Flow Diagrams
 
 Generating Flow Diagrams turns AI-agent workflow descriptions into auditable
-Markdown documents with Mermaid flowcharts. The skill treats a flow diagram as
-an operating contract: it must show authority, evidence, validation, decision
-logic, human gates, outputs, and terminal states clearly enough to inspect.
+Markdown documents with Mermaid flowcharts. It treats a diagram as an operating
+contract: the result should expose authority, evidence, validation, decisions,
+human gates, outputs, and terminal states clearly enough to inspect.
 
-Use this skill for new diagrams and for refinement requests. When refining an
-existing flow, preserve user intent by identifying improvement gaps first and
-asking for confirmation before filling, fixing, or redefining them.
+The orchestrator coordinates the run, keeps only decisions and verdicts in
+context, and loads detailed guidance only when a phase needs it. External links
+are optional source material; the bundled files are enough to run offline.
 
 ## Inputs
 
@@ -33,160 +33,72 @@ asking for confirmation before filling, fixing, or redefining them.
 | `REFINEMENT_REQUEST` | No | `Improve the current diagram without changing scope` |
 | `APPROVED_REFINEMENT_GAPS` | No | `Add human gate and blocked terminal state only` |
 
-Ask one concise clarifying question only when a missing input would change the
-diagram contract. If enough information exists to make assumptions safely, mark
-those assumptions instead of presenting them as facts.
+Ask one concise clarifying question only when a missing value would change the
+diagram contract. If assumptions are safe and reversible, mark them explicitly.
 
-## Workflow
+## Progressive Loading Map
 
-| Phase | Action | Output |
-| ----- | ------ | ------ |
-| 1 | Frame boundary, role, objective, authority, and trust model | Boundary paragraph |
-| 2 | Map inputs, outputs, evidence, risks, dependencies, and completion outcomes | Diagram outline |
-| 2a | For refinement requests, inspect the existing flow and ask approval for proposed gaps | Gap inventory or approved scope |
-| 3 | Build the Mermaid `flowchart TD` unless another Mermaid type is clearly better | Candidate diagram |
-| 4 | Add failure paths, human gates, decline paths, and audit or handoff paths | Guardrailed diagram |
-| 5 | Apply Mermaid formatting, short labels, line breaks, and classes | Readable Mermaid |
-| 6 | Self-review for safety, branch integrity, grounding, and syntax | Revised candidate |
-| 7 | Run the quality gate loop until the candidate passes | Final Markdown or blocker |
+| Need | Load |
+| ---- | ---- |
+| Refinement gap inventory and confirmation gate | Dispatch `./subagents/refinement-analyst.md`; load `./references/output-templates.md` only to format the user-facing confirmation request |
+| Diagram structure, human gates, failure paths, and category separation | Dispatch `./subagents/diagram-builder.md`; it loads `./references/flow-design-playbook.md` |
+| Mermaid syntax, classes, and style pitfalls | Dispatch `./subagents/diagram-builder.md`; it loads `./references/mermaid-style-guide.md` |
+| Final Markdown assembly | Dispatch `./subagents/diagram-builder.md`; it loads `./references/output-templates.md` |
+| Quality gate and fix loop | Dispatch `./subagents/diagram-quality-reviewer.md`; it loads `./references/quality-gate-checklist.md` |
+| Source-backed rationale or current Mermaid guidance | `./references/external-sources.md`, then fetch the smallest relevant URL |
+
+## Subagent Registry
+
+| Subagent | Path | Purpose |
+| -------- | ---- | ------- |
+| `refinement-analyst` | `./subagents/refinement-analyst.md` | Inspects an existing flow and returns proposed improvement gaps plus a confirmation question |
+| `diagram-builder` | `./subagents/diagram-builder.md` | Creates or revises the Markdown plus Mermaid candidate from approved scope and bundled references |
+| `diagram-quality-reviewer` | `./subagents/diagram-quality-reviewer.md` | Reviews the candidate for Mermaid validity, prompt compliance, and approved refinement scope |
+
+Read a subagent file only when dispatching that subagent. Keep raw diagrams,
+candidate drafts, and detailed findings inside subagents except for the final
+candidate that must be returned to the user.
 
 ## How This Skill Works
 
-The skill does three things:
+The orchestrator does three things:
 
-- Design: convert the process into nodes, decisions, checks, gates, outputs, and terminal states.
-- Protect: keep sensitive actions behind human gates and preserve confirmed user intent during refinements.
-- Validate: reject invalid Mermaid or instruction-noncompliant candidates and iterate until the quality gate passes.
+- Decide: classify the request as new generation or refinement and choose the next phase.
+- Dispatch: send detailed analysis, building, or validation to the bundled subagent for that phase.
+- Synthesize: keep concise verdicts, user confirmations, and final output only.
 
 ## Execution
 
-1. Capture the required inputs and any existing flow, diagram, file content, or refinement request.
-2. If refining an existing flow, run the refinement pre-check before generating a new diagram.
-3. Define the operating boundary: agent role, objective, allowed actions, forbidden actions, sensitive actions, trust model, and read-only or mutation limits.
-4. Map process material into concrete stages: intake, context collection, classification, validation, evidence synthesis, decisions, failure paths, human gates, output generation, and terminal states.
-5. Draft one Mermaid diagram in a fenced `mermaid` block, using `flowchart TD` unless another Mermaid diagram type is clearly better.
-6. Add class definitions and class assignments for guardrails, checks, decisions, human gates, outputs, and terminal states.
-7. Self-review and fix missing gates, mutation paths without authorization, dead-end branches, unclear decisions, disconnected validation, unsupported facts, and Mermaid syntax issues.
-8. Run the quality gate. If any check fails, reject the candidate, revise the relevant phase output, and run the quality gate again.
-9. Return the final Markdown only after the quality gate passes. If required information or refinement approval is missing, return the blocker or confirmation request instead.
-
-## Refinement Pre-Check
-
-Run this gate when the user provides an existing Mermaid diagram, flow, process
-description, or file to refine.
-
-1. Inspect the existing flow without rewriting it.
-2. List concrete gaps that could be improved, such as missing gates, unclear authority, unsupported assumptions, disconnected validation, dead-end branches, malformed Mermaid, missing terminal states, weak evidence handling, or absent failure paths.
-3. Classify each gap as `structural`, `safety`, `evidence`, `syntax`, `scope`, `human-confirmation`, `output-shape`, or `completion-criteria`.
-4. Ask the user which gaps are approved for the generated flow before filling, fixing, or redefining them.
-5. Generate the revised flow only for explicitly approved gaps.
-
-If gaps are found and approval is missing, stop and return only:
-
-```markdown
-## Refinement Pre-Check
-| Gap | Type | Why It Matters | Proposed Change |
-| --- | ---- | -------------- | --------------- |
-| ... | ... | ... | ... |
-
-Which gaps should I include or fix in the revised flow?
-```
-
-## Diagram Requirements
-
-Include these elements when relevant to the process:
-
-- Start node.
-- Boundary and authority node.
-- Intake or context snapshot node.
-- Access or evidence availability decision.
-- Classification node.
-- Parallel or grouped validation checks.
-- Evidence synthesis node.
-- Contradiction or invalid-claim decision.
-- Missing-information decision.
-- Scope or decomposition decision.
-- Risk or dependency decision.
-- Human confirmation gates for sensitive actions.
-- Output, report, or comment drafting node.
-- Final readiness decision.
-- Terminal states such as ready, needs refinement, blocked, deferred, not actionable, or escalated.
-
-For each human-in-the-loop gate, include the exact action, target, reason, risk
-and reversibility, safer alternative, explicit approve branch, explicit decline
-branch, and audit or handoff requirement after approval.
-
-## Mermaid Style
-
-Use short, action-oriented node names such as `COLLECT_CONTEXT`,
-`VERIFY_CLAIMS`, `ASK_HUMAN`, and `POST_REPORT`. Use `\n` when a concise label
-needs one clarifying detail.
-
-Use class definitions similar to:
-
-```mermaid
-classDef guard fill:#fff3cd,stroke:#856404,color:#000;
-classDef check fill:#e7f1ff,stroke:#0b5ed7,color:#000;
-classDef decision fill:#f8f9fa,stroke:#495057,color:#000;
-classDef human fill:#f3e8ff,stroke:#6f42c1,color:#000;
-classDef output fill:#e8f5e9,stroke:#2e7d32,color:#000;
-classDef stop fill:#fdecea,stroke:#b02a37,color:#000;
-```
-
-## Anti-Patterns
-
-Do not:
-
-- Generate implementation details, code, tool commands, or production changes instead of a process design.
-- Let a sensitive or risky action bypass human confirmation.
-- Fill or fix gaps in an existing flow before the user confirms which gaps should be included.
-- Return a diagram that failed the quality gate.
-- Treat placeholders, assumptions, or missing evidence as confirmed facts.
-- Use vague nodes such as `Process item`, `Handle issue`, `Review stuff`, or `Do work`.
-- Leave dead-end branches, unlabeled decision outcomes, or validation checks disconnected from readiness.
-- Produce Mermaid with undefined nodes, conflicting duplicate node definitions, malformed arrows, or class assignments for classes that are not defined.
-
-## Quality Gate
-
-Treat the generated Mermaid diagram as a candidate until it passes validation. A
-candidate fails if Mermaid syntax is invalid, required nodes or paths are
-missing, sensitive actions bypass human approval, unconfirmed refinement gaps
-were applied, validation checks do not affect readiness, unsupported facts
-appear as confirmed, terminal states are missing, or output format does not
-match this skill.
-
-Reject failed candidates and iterate until the gate passes. If a valid diagram
-cannot be produced because required information or user confirmation is missing,
-return the blocker or confirmation request instead of a final diagram.
+1. Capture all inputs and classify the run as `new` or `refinement`.
+2. For `refinement`, dispatch `refinement-analyst` before generating a revised diagram. If it returns `NEEDS_CONFIRMATION`, ask the confirmation question and stop.
+3. Load orchestration-level references only when the orchestrator must format a user-facing confirmation or fetch external rationale. Detailed design, Mermaid, and quality references are loaded by the dispatched subagent.
+4. Dispatch `diagram-builder` with the original inputs, approved gaps, and any concise constraints from prior phases.
+5. Dispatch `diagram-quality-reviewer` with the candidate output and applicable inputs.
+6. If review fails, send only the failed checks and candidate back to `diagram-builder`; re-run the reviewer. Stop after three fix cycles and ask the user how to proceed.
+7. Return the final Markdown only after `diagram-quality-reviewer` returns `REVIEW: PASS`.
 
 ## Output Contract
 
-Return a Markdown document with this structure after the quality gate passes:
+If refinement approval is required, return the pre-check table and confirmation
+question from `refinement-analyst`.
 
-1. A short title using `PROCESS_NAME`.
-2. A short paragraph describing the workflow boundary, authority, trust model, and read-only or mutation limits.
-3. Exactly one Mermaid diagram in a fenced `mermaid` block unless the user explicitly asks for multiple diagrams.
-4. Optional output, report, or comment template in a fenced `text` block when useful.
-5. Optional readiness, completion, or sensitive-action rule when it clarifies successful completion.
+After the quality gate passes, return a Markdown document with:
 
-Separate facts, assumptions, risks, blockers, recommendations, and unresolved
-questions in the diagram or supporting text. If the refinement pre-check needs
-approval, return the gap inventory and confirmation question instead of this
-final output.
+- A short title using `PROCESS_NAME`.
+- A short boundary paragraph covering role, authority, trust model, and mutation limits.
+- Exactly one fenced `mermaid` diagram unless the user explicitly asks for more.
+- Optional output, report, or comment template when useful.
+- Optional readiness, completion, or sensitive-action rule when it clarifies completion.
 
-## Success Criteria
+## Validation
 
-- The final Markdown contains a title, boundary paragraph, and one valid Mermaid diagram.
-- The diagram starts with process intake and ends only at explicit terminal states.
-- Context collection, classification, validation checks, evidence synthesis, decision points, failure paths, human gates, output generation, and readiness logic are represented.
-- Every sensitive action routes through a human gate with approve and decline branches.
-- Read-only or reviewer-only boundaries route mutations to recommendations or separate approved workflows.
-- Missing access, missing information, contradictory evidence, invalid claims, oversized scope, dependencies, and escalation have paths when relevant.
-- Facts, assumptions, risks, blockers, recommendations, and unresolved questions are separated.
-- Mermaid classes are defined and applied consistently.
-- No unsupported facts are invented.
-- For refinement requests, proposed gaps were identified first and only user-approved gaps were included, filled, fixed, or redefined.
-- The quality gate passed after the final iteration.
+A valid run satisfies these checks:
+
+- `SKILL.md` stays a routing layer; detailed templates, style guidance, quality checks, and external links live in `references/`.
+- Local paths referenced by this skill exist inside this package.
+- Refinements include only user-approved gap fixes.
+- The final Mermaid candidate passes the quality gate after at most three targeted fix cycles.
+- External URLs are optional just-in-time sources, not required runtime dependencies.
 
 ## Example
 
@@ -194,8 +106,8 @@ Input: `Create a flow diagram for an AI-assisted deployment review. The agent ma
 read release artifacts and post a readiness comment, but it may not deploy,
 merge, or bypass CI. Deployment and rollback are sensitive actions.`
 
-1. Frame the reviewer role, release-readiness objective, and read-only boundary.
-2. Add evidence checks for CI, changelog, rollback plan, incidents, and runbooks.
-3. Route deploy or rollback recommendations through a human gate.
-4. Add blocked, needs validation, ready, and escalated terminal states.
-5. Run the quality gate and return the Markdown plus Mermaid only after it passes.
+1. Orchestrator classifies the run as `new`.
+2. Orchestrator loads `flow-design-playbook.md`, `mermaid-style-guide.md`, and `output-templates.md`.
+3. Orchestrator dispatches `diagram-builder` and receives a candidate Markdown document.
+4. Orchestrator dispatches `diagram-quality-reviewer`.
+5. If review passes, the final Markdown is returned. If review fails, only the failed checks are sent back for targeted repair.

--- a/skills/generating-flow-diagrams/SKILL.md
+++ b/skills/generating-flow-diagrams/SKILL.md
@@ -73,9 +73,10 @@ The orchestrator does three things:
 2. For `refinement`, dispatch `refinement-analyst` before generating a revised diagram. Continue only on `PREFLIGHT: PASS`; on `PREFLIGHT: NEEDS_CONFIRMATION`, ask the confirmation question and stop; on `PREFLIGHT: BLOCKED` or `PREFLIGHT: ERROR`, stop with the reported recovery action.
 3. Load orchestration-level references only when the orchestrator must format a user-facing confirmation or fetch external rationale. Detailed design, Mermaid, and quality references are loaded by the dispatched subagent.
 4. Dispatch `diagram-builder` with the original inputs, approved gaps, and any concise constraints from prior phases.
-5. Dispatch `diagram-quality-reviewer` with the candidate output and applicable inputs.
-6. If review fails, dispatch `diagram-builder` with the current candidate, `RUN_MODE=repair`, and `REVIEW_FEEDBACK` containing only the failed checks; re-run the reviewer. Stop after three fix cycles and ask the user how to proceed.
-7. Return the final Markdown only after `diagram-quality-reviewer` returns `REVIEW: PASS`.
+5. Continue only on `BUILD: PASS`; on `BUILD: NEEDS_INPUT` or `BUILD: ERROR`, stop with `Failure Details` and the reported recovery action.
+6. Dispatch `diagram-quality-reviewer` with the candidate output and applicable inputs.
+7. If review fails, dispatch `diagram-builder` with the current candidate, `RUN_MODE=repair`, and `REVIEW_FEEDBACK` containing only the failed checks; re-run the reviewer. Stop after three fix cycles and ask the user how to proceed.
+8. Return the final Markdown only after `diagram-quality-reviewer` returns `REVIEW: PASS`.
 
 ## Output Contract
 

--- a/skills/generating-flow-diagrams/SKILL.md
+++ b/skills/generating-flow-diagrams/SKILL.md
@@ -75,7 +75,7 @@ The orchestrator does three things:
 4. Dispatch `diagram-builder` with the original inputs, approved gaps, and any concise constraints from prior phases.
 5. Continue only on `BUILD: PASS`; on `BUILD: NEEDS_INPUT` or `BUILD: ERROR`, stop with `Failure Details` and the reported recovery action.
 6. Dispatch `diagram-quality-reviewer` with the candidate output and applicable inputs.
-7. If review fails, dispatch `diagram-builder` with the current candidate, `RUN_MODE=repair`, and `REVIEW_FEEDBACK` containing only the failed checks; re-run the reviewer. Stop after three fix cycles and ask the user how to proceed.
+7. On `REVIEW: BLOCKED` or `REVIEW: ERROR`, stop with the validation blocker and recovery action. If `REVIEW: FAIL`, dispatch `diagram-builder` with the current candidate, `RUN_MODE=repair`, and `REVIEW_FEEDBACK` containing only the failed checks; if repair returns `BUILD: NEEDS_INPUT` or `BUILD: ERROR`, stop with `Failure Details`; otherwise re-run the reviewer. Stop after three fix cycles and ask the user how to proceed.
 8. Return the final Markdown only after `diagram-quality-reviewer` returns `REVIEW: PASS`.
 
 ## Output Contract

--- a/skills/generating-flow-diagrams/SKILL.md
+++ b/skills/generating-flow-diagrams/SKILL.md
@@ -74,7 +74,7 @@ The orchestrator does three things:
 3. Load orchestration-level references only when the orchestrator must format a user-facing confirmation or fetch external rationale. Detailed design, Mermaid, and quality references are loaded by the dispatched subagent.
 4. Dispatch `diagram-builder` with the original inputs, approved gaps, and any concise constraints from prior phases.
 5. Dispatch `diagram-quality-reviewer` with the candidate output and applicable inputs.
-6. If review fails, send only the failed checks and candidate back to `diagram-builder`; re-run the reviewer. Stop after three fix cycles and ask the user how to proceed.
+6. If review fails, dispatch `diagram-builder` with the current candidate, `RUN_MODE=repair`, and `REVIEW_FEEDBACK` containing only the failed checks; re-run the reviewer. Stop after three fix cycles and ask the user how to proceed.
 7. Return the final Markdown only after `diagram-quality-reviewer` returns `REVIEW: PASS`.
 
 ## Output Contract

--- a/skills/generating-flow-diagrams/SKILL.md
+++ b/skills/generating-flow-diagrams/SKILL.md
@@ -107,7 +107,7 @@ read release artifacts and post a readiness comment, but it may not deploy,
 merge, or bypass CI. Deployment and rollback are sensitive actions.`
 
 1. Orchestrator classifies the run as `new`.
-2. Orchestrator loads `flow-design-playbook.md`, `mermaid-style-guide.md`, and `output-templates.md`.
-3. Orchestrator dispatches `diagram-builder` and receives a candidate Markdown document.
+2. Orchestrator dispatches `diagram-builder` with `RUN_MODE=new`.
+3. `diagram-builder` loads `flow-design-playbook.md`, `mermaid-style-guide.md`, and `output-templates.md`, then returns a candidate Markdown document.
 4. Orchestrator dispatches `diagram-quality-reviewer`.
-5. If review passes, the final Markdown is returned. If review fails, only the failed checks are sent back for targeted repair.
+5. If review passes, the final Markdown is returned. If review fails, the orchestrator re-dispatches `diagram-builder` with the current candidate, `RUN_MODE=repair`, and `REVIEW_FEEDBACK` containing only the failed checks.

--- a/skills/generating-flow-diagrams/SKILL.md
+++ b/skills/generating-flow-diagrams/SKILL.md
@@ -70,7 +70,7 @@ The orchestrator does three things:
 ## Execution
 
 1. Capture all inputs and classify the run as `new` or `refinement`.
-2. For `refinement`, dispatch `refinement-analyst` before generating a revised diagram. If it returns `PREFLIGHT: NEEDS_CONFIRMATION`, ask the confirmation question and stop.
+2. For `refinement`, dispatch `refinement-analyst` before generating a revised diagram. Continue only on `PREFLIGHT: PASS`; on `PREFLIGHT: NEEDS_CONFIRMATION`, ask the confirmation question and stop; on `PREFLIGHT: BLOCKED` or `PREFLIGHT: ERROR`, stop with the reported recovery action.
 3. Load orchestration-level references only when the orchestrator must format a user-facing confirmation or fetch external rationale. Detailed design, Mermaid, and quality references are loaded by the dispatched subagent.
 4. Dispatch `diagram-builder` with the original inputs, approved gaps, and any concise constraints from prior phases.
 5. Dispatch `diagram-quality-reviewer` with the candidate output and applicable inputs.

--- a/skills/generating-flow-diagrams/SKILL.md
+++ b/skills/generating-flow-diagrams/SKILL.md
@@ -31,7 +31,7 @@ are optional source material; the bundled files are enough to run offline.
 | `COMPLETION_CRITERIA` | Yes | `Ready, blocked, needs more validation, escalated` |
 | `EXISTING_FLOW_OR_DIAGRAM` | No | Existing Mermaid block, file, or process description |
 | `REFINEMENT_REQUEST` | No | `Improve the current diagram without changing scope` |
-| `APPROVED_REFINEMENT_GAPS` | No | `Add human gate and blocked terminal state only` |
+| `APPROVED_REFINEMENT_GAPS` | No | `G1 and G3 only` |
 
 Ask one concise clarifying question only when a missing value would change the
 diagram contract. If assumptions are safe and reversible, mark them explicitly.

--- a/skills/generating-flow-diagrams/SKILL.md
+++ b/skills/generating-flow-diagrams/SKILL.md
@@ -111,4 +111,4 @@ merge, or bypass CI. Deployment and rollback are sensitive actions.`
 2. Orchestrator dispatches `diagram-builder` with `RUN_MODE=new`.
 3. `diagram-builder` loads `flow-design-playbook.md`, `mermaid-style-guide.md`, and `output-templates.md`, then returns a candidate Markdown document.
 4. Orchestrator dispatches `diagram-quality-reviewer`.
-5. If review passes, the final Markdown is returned. If review fails, the orchestrator re-dispatches `diagram-builder` with the current candidate, `RUN_MODE=repair`, and `REVIEW_FEEDBACK` containing only the failed checks.
+5. If review passes, the final Markdown is returned. If review fails, the orchestrator re-dispatches `diagram-builder` with the current candidate, `RUN_MODE=repair`, and `REVIEW_FEEDBACK` containing only the failed checks. If any subagent returns a blocked, needs-input, or error status, the orchestrator stops with the reported recovery action.

--- a/skills/generating-flow-diagrams/SKILL.md
+++ b/skills/generating-flow-diagrams/SKILL.md
@@ -70,7 +70,7 @@ The orchestrator does three things:
 ## Execution
 
 1. Capture all inputs and classify the run as `new` or `refinement`.
-2. For `refinement`, dispatch `refinement-analyst` before generating a revised diagram. If it returns `NEEDS_CONFIRMATION`, ask the confirmation question and stop.
+2. For `refinement`, dispatch `refinement-analyst` before generating a revised diagram. If it returns `PREFLIGHT: NEEDS_CONFIRMATION`, ask the confirmation question and stop.
 3. Load orchestration-level references only when the orchestrator must format a user-facing confirmation or fetch external rationale. Detailed design, Mermaid, and quality references are loaded by the dispatched subagent.
 4. Dispatch `diagram-builder` with the original inputs, approved gaps, and any concise constraints from prior phases.
 5. Dispatch `diagram-quality-reviewer` with the candidate output and applicable inputs.

--- a/skills/generating-flow-diagrams/SKILL.md
+++ b/skills/generating-flow-diagrams/SKILL.md
@@ -1,0 +1,201 @@
+---
+name: "generating-flow-diagrams"
+description: "Create or refine Markdown plus Mermaid flow diagrams for AI-agent workflows. Use when the user asks for a process flow, workflow diagram, Mermaid flowchart, agent operating procedure, human-in-the-loop gate map, or refinement of an existing flow or process description."
+---
+
+# Generating Flow Diagrams
+
+Generating Flow Diagrams turns AI-agent workflow descriptions into auditable
+Markdown documents with Mermaid flowcharts. The skill treats a flow diagram as
+an operating contract: it must show authority, evidence, validation, decision
+logic, human gates, outputs, and terminal states clearly enough to inspect.
+
+Use this skill for new diagrams and for refinement requests. When refining an
+existing flow, preserve user intent by identifying improvement gaps first and
+asking for confirmation before filling, fixing, or redefining them.
+
+## Inputs
+
+| Input | Required | Example |
+| ----- | -------- | ------- |
+| `PROCESS_NAME` | Yes | `AI-assisted production deployment review` |
+| `AGENT_ROLE` | Yes | `Deployment reviewer` |
+| `PRIMARY_OBJECTIVE` | Yes | `Decide whether a release candidate is safe to deploy` |
+| `INPUTS` | Yes | `PR, CI results, changelog, rollback plan` |
+| `OUTPUTS` | Yes | `Deployment readiness comment` |
+| `ALLOWED_ACTIONS` | Yes | `Read artifacts, summarize risks, post readiness comment` |
+| `FORBIDDEN_ACTIONS` | Yes | `Trigger deploy, merge PR, bypass CI` |
+| `SENSITIVE_ACTIONS` | Yes | `Deploy, rollback, change feature flags` |
+| `HUMAN_CONFIRMATION_REQUIREMENTS` | Yes | `Explicit approval before recommending deploy` |
+| `EVIDENCE_SOURCES` | Yes | `CI, incident history, runbooks` |
+| `COMPLETION_CRITERIA` | Yes | `Ready, blocked, needs more validation, escalated` |
+| `EXISTING_FLOW_OR_DIAGRAM` | No | Existing Mermaid block, file, or process description |
+| `REFINEMENT_REQUEST` | No | `Improve the current diagram without changing scope` |
+| `APPROVED_REFINEMENT_GAPS` | No | `Add human gate and blocked terminal state only` |
+
+Ask one concise clarifying question only when a missing input would change the
+diagram contract. If enough information exists to make assumptions safely, mark
+those assumptions instead of presenting them as facts.
+
+## Workflow
+
+| Phase | Action | Output |
+| ----- | ------ | ------ |
+| 1 | Frame boundary, role, objective, authority, and trust model | Boundary paragraph |
+| 2 | Map inputs, outputs, evidence, risks, dependencies, and completion outcomes | Diagram outline |
+| 2a | For refinement requests, inspect the existing flow and ask approval for proposed gaps | Gap inventory or approved scope |
+| 3 | Build the Mermaid `flowchart TD` unless another Mermaid type is clearly better | Candidate diagram |
+| 4 | Add failure paths, human gates, decline paths, and audit or handoff paths | Guardrailed diagram |
+| 5 | Apply Mermaid formatting, short labels, line breaks, and classes | Readable Mermaid |
+| 6 | Self-review for safety, branch integrity, grounding, and syntax | Revised candidate |
+| 7 | Run the quality gate loop until the candidate passes | Final Markdown or blocker |
+
+## How This Skill Works
+
+The skill does three things:
+
+- Design: convert the process into nodes, decisions, checks, gates, outputs, and terminal states.
+- Protect: keep sensitive actions behind human gates and preserve confirmed user intent during refinements.
+- Validate: reject invalid Mermaid or instruction-noncompliant candidates and iterate until the quality gate passes.
+
+## Execution
+
+1. Capture the required inputs and any existing flow, diagram, file content, or refinement request.
+2. If refining an existing flow, run the refinement pre-check before generating a new diagram.
+3. Define the operating boundary: agent role, objective, allowed actions, forbidden actions, sensitive actions, trust model, and read-only or mutation limits.
+4. Map process material into concrete stages: intake, context collection, classification, validation, evidence synthesis, decisions, failure paths, human gates, output generation, and terminal states.
+5. Draft one Mermaid diagram in a fenced `mermaid` block, using `flowchart TD` unless another Mermaid diagram type is clearly better.
+6. Add class definitions and class assignments for guardrails, checks, decisions, human gates, outputs, and terminal states.
+7. Self-review and fix missing gates, mutation paths without authorization, dead-end branches, unclear decisions, disconnected validation, unsupported facts, and Mermaid syntax issues.
+8. Run the quality gate. If any check fails, reject the candidate, revise the relevant phase output, and run the quality gate again.
+9. Return the final Markdown only after the quality gate passes. If required information or refinement approval is missing, return the blocker or confirmation request instead.
+
+## Refinement Pre-Check
+
+Run this gate when the user provides an existing Mermaid diagram, flow, process
+description, or file to refine.
+
+1. Inspect the existing flow without rewriting it.
+2. List concrete gaps that could be improved, such as missing gates, unclear authority, unsupported assumptions, disconnected validation, dead-end branches, malformed Mermaid, missing terminal states, weak evidence handling, or absent failure paths.
+3. Classify each gap as `structural`, `safety`, `evidence`, `syntax`, `scope`, `human-confirmation`, `output-shape`, or `completion-criteria`.
+4. Ask the user which gaps are approved for the generated flow before filling, fixing, or redefining them.
+5. Generate the revised flow only for explicitly approved gaps.
+
+If gaps are found and approval is missing, stop and return only:
+
+```markdown
+## Refinement Pre-Check
+| Gap | Type | Why It Matters | Proposed Change |
+| --- | ---- | -------------- | --------------- |
+| ... | ... | ... | ... |
+
+Which gaps should I include or fix in the revised flow?
+```
+
+## Diagram Requirements
+
+Include these elements when relevant to the process:
+
+- Start node.
+- Boundary and authority node.
+- Intake or context snapshot node.
+- Access or evidence availability decision.
+- Classification node.
+- Parallel or grouped validation checks.
+- Evidence synthesis node.
+- Contradiction or invalid-claim decision.
+- Missing-information decision.
+- Scope or decomposition decision.
+- Risk or dependency decision.
+- Human confirmation gates for sensitive actions.
+- Output, report, or comment drafting node.
+- Final readiness decision.
+- Terminal states such as ready, needs refinement, blocked, deferred, not actionable, or escalated.
+
+For each human-in-the-loop gate, include the exact action, target, reason, risk
+and reversibility, safer alternative, explicit approve branch, explicit decline
+branch, and audit or handoff requirement after approval.
+
+## Mermaid Style
+
+Use short, action-oriented node names such as `COLLECT_CONTEXT`,
+`VERIFY_CLAIMS`, `ASK_HUMAN`, and `POST_REPORT`. Use `\n` when a concise label
+needs one clarifying detail.
+
+Use class definitions similar to:
+
+```mermaid
+classDef guard fill:#fff3cd,stroke:#856404,color:#000;
+classDef check fill:#e7f1ff,stroke:#0b5ed7,color:#000;
+classDef decision fill:#f8f9fa,stroke:#495057,color:#000;
+classDef human fill:#f3e8ff,stroke:#6f42c1,color:#000;
+classDef output fill:#e8f5e9,stroke:#2e7d32,color:#000;
+classDef stop fill:#fdecea,stroke:#b02a37,color:#000;
+```
+
+## Anti-Patterns
+
+Do not:
+
+- Generate implementation details, code, tool commands, or production changes instead of a process design.
+- Let a sensitive or risky action bypass human confirmation.
+- Fill or fix gaps in an existing flow before the user confirms which gaps should be included.
+- Return a diagram that failed the quality gate.
+- Treat placeholders, assumptions, or missing evidence as confirmed facts.
+- Use vague nodes such as `Process item`, `Handle issue`, `Review stuff`, or `Do work`.
+- Leave dead-end branches, unlabeled decision outcomes, or validation checks disconnected from readiness.
+- Produce Mermaid with undefined nodes, conflicting duplicate node definitions, malformed arrows, or class assignments for classes that are not defined.
+
+## Quality Gate
+
+Treat the generated Mermaid diagram as a candidate until it passes validation. A
+candidate fails if Mermaid syntax is invalid, required nodes or paths are
+missing, sensitive actions bypass human approval, unconfirmed refinement gaps
+were applied, validation checks do not affect readiness, unsupported facts
+appear as confirmed, terminal states are missing, or output format does not
+match this skill.
+
+Reject failed candidates and iterate until the gate passes. If a valid diagram
+cannot be produced because required information or user confirmation is missing,
+return the blocker or confirmation request instead of a final diagram.
+
+## Output Contract
+
+Return a Markdown document with this structure after the quality gate passes:
+
+1. A short title using `PROCESS_NAME`.
+2. A short paragraph describing the workflow boundary, authority, trust model, and read-only or mutation limits.
+3. Exactly one Mermaid diagram in a fenced `mermaid` block unless the user explicitly asks for multiple diagrams.
+4. Optional output, report, or comment template in a fenced `text` block when useful.
+5. Optional readiness, completion, or sensitive-action rule when it clarifies successful completion.
+
+Separate facts, assumptions, risks, blockers, recommendations, and unresolved
+questions in the diagram or supporting text. If the refinement pre-check needs
+approval, return the gap inventory and confirmation question instead of this
+final output.
+
+## Success Criteria
+
+- The final Markdown contains a title, boundary paragraph, and one valid Mermaid diagram.
+- The diagram starts with process intake and ends only at explicit terminal states.
+- Context collection, classification, validation checks, evidence synthesis, decision points, failure paths, human gates, output generation, and readiness logic are represented.
+- Every sensitive action routes through a human gate with approve and decline branches.
+- Read-only or reviewer-only boundaries route mutations to recommendations or separate approved workflows.
+- Missing access, missing information, contradictory evidence, invalid claims, oversized scope, dependencies, and escalation have paths when relevant.
+- Facts, assumptions, risks, blockers, recommendations, and unresolved questions are separated.
+- Mermaid classes are defined and applied consistently.
+- No unsupported facts are invented.
+- For refinement requests, proposed gaps were identified first and only user-approved gaps were included, filled, fixed, or redefined.
+- The quality gate passed after the final iteration.
+
+## Example
+
+Input: `Create a flow diagram for an AI-assisted deployment review. The agent may
+read release artifacts and post a readiness comment, but it may not deploy,
+merge, or bypass CI. Deployment and rollback are sensitive actions.`
+
+1. Frame the reviewer role, release-readiness objective, and read-only boundary.
+2. Add evidence checks for CI, changelog, rollback plan, incidents, and runbooks.
+3. Route deploy or rollback recommendations through a human gate.
+4. Add blocked, needs validation, ready, and escalated terminal states.
+5. Run the quality gate and return the Markdown plus Mermaid only after it passes.

--- a/skills/generating-flow-diagrams/SKILL.md
+++ b/skills/generating-flow-diagrams/SKILL.md
@@ -36,6 +36,11 @@ are optional source material; the bundled files are enough to run offline.
 Ask one concise clarifying question only when a missing value would change the
 diagram contract. If assumptions are safe and reversible, mark them explicitly.
 
+For subagent dispatches, assemble `PROCESS_INPUTS` as the normalized bundle of
+required top-level process fields, supplied optional context, run classification,
+and explicit assumptions. Keep `APPROVED_REFINEMENT_GAPS` as a separate dispatch
+input so refinement approvals remain visible to the builder and reviewer.
+
 ## Progressive Loading Map
 
 | Need | Load |
@@ -70,13 +75,14 @@ The orchestrator does three things:
 ## Execution
 
 1. Capture all inputs and classify the run as `new` or `refinement`.
-2. For `refinement`, dispatch `refinement-analyst` before generating a revised diagram. Continue only on `PREFLIGHT: PASS`; on `PREFLIGHT: NEEDS_CONFIRMATION`, ask the confirmation question and stop; on `PREFLIGHT: BLOCKED` or `PREFLIGHT: ERROR`, stop with the reported recovery action.
-3. Load orchestration-level references only when the orchestrator must format a user-facing confirmation or fetch external rationale. Detailed design, Mermaid, and quality references are loaded by the dispatched subagent.
-4. Dispatch `diagram-builder` with the original inputs, approved gaps, and any concise constraints from prior phases.
-5. Continue only on `BUILD: PASS`; on `BUILD: NEEDS_INPUT` or `BUILD: ERROR`, stop with `Failure Details` and the reported recovery action.
-6. Dispatch `diagram-quality-reviewer` with the candidate output and applicable inputs.
-7. On `REVIEW: BLOCKED` or `REVIEW: ERROR`, stop with the validation blocker and recovery action. If `REVIEW: FAIL`, dispatch `diagram-builder` with the current candidate, `RUN_MODE=repair`, and `REVIEW_FEEDBACK` containing only the failed checks; if repair returns `BUILD: NEEDS_INPUT` or `BUILD: ERROR`, stop with `Failure Details`; otherwise re-run the reviewer. Stop after three fix cycles and ask the user how to proceed.
-8. Return the final Markdown only after `diagram-quality-reviewer` returns `REVIEW: PASS`.
+2. Assemble `PROCESS_INPUTS` from the normalized top-level process inputs, supplied optional context, run classification, and explicit assumptions.
+3. For `refinement`, dispatch `refinement-analyst` before generating a revised diagram. Continue only on `PREFLIGHT: PASS`; on `PREFLIGHT: NEEDS_CONFIRMATION`, ask the confirmation question and stop; on `PREFLIGHT: BLOCKED` or `PREFLIGHT: ERROR`, stop with the reported recovery action.
+4. Load orchestration-level references only when the orchestrator must format a user-facing confirmation or fetch external rationale. Detailed design, Mermaid, and quality references are loaded by the dispatched subagent.
+5. Dispatch `diagram-builder` with `PROCESS_INPUTS`, `RUN_MODE=new` or `RUN_MODE=refinement`, `APPROVED_REFINEMENT_GAPS` when refinement has approved gaps, and any concise constraints from prior phases.
+6. Continue only on `BUILD: PASS`; on `BUILD: NEEDS_INPUT` or `BUILD: ERROR`, stop with `Failure Details` and the reported recovery action.
+7. Dispatch `diagram-quality-reviewer` with `CANDIDATE_MARKDOWN`, `PROCESS_INPUTS`, `RUN_MODE`, and `APPROVED_REFINEMENT_GAPS` when refinement scope applies.
+8. On `REVIEW: BLOCKED` or `REVIEW: ERROR`, stop with the validation blocker and recovery action. If `REVIEW: FAIL`, dispatch `diagram-builder` with `PROCESS_INPUTS`, the current candidate, `RUN_MODE=repair`, and `REVIEW_FEEDBACK` containing only the failed checks; if repair returns `BUILD: NEEDS_INPUT` or `BUILD: ERROR`, stop with `Failure Details`; otherwise re-run the full reviewer. Stop after three fix cycles and ask the user how to proceed.
+9. Return the final Markdown only after `diagram-quality-reviewer` returns `REVIEW: PASS`.
 
 ## Output Contract
 
@@ -98,7 +104,7 @@ A valid run satisfies these checks:
 - `SKILL.md` stays a routing layer; detailed templates, style guidance, quality checks, and external links live in `references/`.
 - Local paths referenced by this skill exist inside this package.
 - Refinements include only user-approved gap fixes.
-- The final Mermaid candidate passes the quality gate after at most three targeted fix cycles.
+- The final Mermaid candidate passes the quality gate after at most three builder repair cycles; each repair uses targeted `REVIEW_FEEDBACK`, then the full reviewer gate reruns.
 - External URLs are optional just-in-time sources, not required runtime dependencies.
 
 ## Example
@@ -108,7 +114,7 @@ read release artifacts and post a readiness comment, but it may not deploy,
 merge, or bypass CI. Deployment and rollback are sensitive actions.`
 
 1. Orchestrator classifies the run as `new`.
-2. Orchestrator dispatches `diagram-builder` with `RUN_MODE=new`.
+2. Orchestrator assembles `PROCESS_INPUTS` and dispatches `diagram-builder` with `PROCESS_INPUTS` and `RUN_MODE=new`.
 3. `diagram-builder` loads `flow-design-playbook.md`, `mermaid-style-guide.md`, and `output-templates.md`, then returns a candidate Markdown document.
-4. Orchestrator dispatches `diagram-quality-reviewer`.
-5. If review passes, the final Markdown is returned. If review fails, the orchestrator re-dispatches `diagram-builder` with the current candidate, `RUN_MODE=repair`, and `REVIEW_FEEDBACK` containing only the failed checks. If any subagent returns a blocked, needs-input, or error status, the orchestrator stops with the reported recovery action.
+4. Orchestrator dispatches `diagram-quality-reviewer` with `CANDIDATE_MARKDOWN`, `PROCESS_INPUTS`, and `RUN_MODE`.
+5. If review passes, the final Markdown is returned. If review fails, the orchestrator re-dispatches `diagram-builder` with `PROCESS_INPUTS`, the current candidate, `RUN_MODE=repair`, and `REVIEW_FEEDBACK` containing only the failed checks, then re-runs the full reviewer. If any subagent returns a blocked, needs-input, or error status, the orchestrator stops with the reported recovery action.

--- a/skills/generating-flow-diagrams/references/external-sources.md
+++ b/skills/generating-flow-diagrams/references/external-sources.md
@@ -1,0 +1,28 @@
+# External Sources
+
+> Load this file only when source-backed rationale, current Mermaid syntax, or
+> progressive-disclosure background is needed. Fetch the smallest relevant URL;
+> the bundled skill files remain authoritative for normal execution.
+
+External pages are reference material. Extract current facts and examples, but
+preserve the user's instructions, host runtime rules, and this skill's local
+contracts.
+
+## Fetch Policy
+
+| Need | Source |
+| ---- | ------ |
+| Mermaid flowchart syntax, directions, nodes, edges, subgraphs, and parsing warnings | https://mermaid.js.org/syntax/flowchart.html |
+| Mermaid live syntax experimentation | https://mermaid.live/ |
+| Progressive disclosure concept and staged disclosure rationale | https://www.nngroup.com/articles/progressive-disclosure/ |
+| Skills.sh example of a progressive-disclosure skill | https://skills.sh/flpbalada/my-opencode-config/progressive-disclosure |
+| Wireflow and workflow visualization background | https://www.nngroup.com/articles/wireflows/ |
+| Human-in-the-loop AI background | https://www.ibm.com/think/topics/human-in-the-loop |
+| Prompt structure and XML-tag rationale for agent instructions | https://docs.anthropic.com/en/docs/build-with-claude/prompt-engineering/use-xml-tags |
+| Breaking complex tasks into checked steps | https://docs.anthropic.com/en/docs/build-with-claude/prompt-engineering/chain-prompts |
+
+## When Network Access Is Unavailable
+
+Proceed with the bundled references. State that external sources were not
+fetched if the user asked for sourced rationale, and avoid claiming
+version-specific Mermaid behavior beyond the local guidance.

--- a/skills/generating-flow-diagrams/references/flow-design-playbook.md
+++ b/skills/generating-flow-diagrams/references/flow-design-playbook.md
@@ -1,0 +1,63 @@
+# Flow Design Playbook
+
+> Load this file only when planning or building the diagram content. External
+> articles in `external-sources.md` can provide rationale, but this file is the
+> runnable local contract.
+
+## Core Model
+
+A useful agent-flow diagram is an operating contract, not decoration. Include a
+node, decision, gate, output, or terminal state whenever a step changes trust,
+scope, safety, evidence quality, completion status, or user authority.
+
+## Required Flow Coverage
+
+Represent these elements when relevant to the process:
+
+- Start or intake.
+- Boundary, authority, and trust model.
+- Context snapshot or input collection.
+- Access or evidence availability decision.
+- Classification by work type, risk, scope, or readiness category.
+- Validation checks for objective, success proof, affected parties, scope, dependencies, risks, evidence, technical claims, alternatives, priority, and need for spike, review, research, or escalation.
+- Evidence synthesis.
+- Decisions for contradictory evidence, invalid claims, missing information, oversized scope, dependencies, and escalation.
+- Human confirmation gates for sensitive actions.
+- Output, report, comment, or artifact drafting.
+- Final readiness or completion decision.
+- Terminal states such as ready, needs refinement, blocked, deferred, not actionable, or escalated.
+
+## Human Gate Contract
+
+For every sensitive action, include:
+
+- Exact action being considered.
+- Target of the action.
+- Reason for the action.
+- Risk and reversibility.
+- Safer alternative.
+- Explicit approve branch.
+- Explicit decline branch.
+- Audit, record, or handoff requirement after approval.
+
+## Boundary Rules
+
+Use positive framing in the diagram: show what the agent may do, where it must
+ask, and where it must stop. If a workflow is read-only or reviewer-only, route
+mutations to recommendations or to a separate approved workflow.
+
+## Ambiguity Handling
+
+When a required detail is unknown, represent it as a question, assumption,
+blocker, or unresolved decision. If missing information prevents a meaningful
+diagram, route to a blocked terminal state.
+
+Unexpected risks, contradictions, unsupported claims, missing dependencies, or
+out-of-scope actions should route to blocker, refinement, research, or escalation
+paths rather than being resolved silently.
+
+## Category Separation
+
+Separate these categories in the diagram or supporting text when they are
+present: facts, assumptions, risks, blockers, recommendations, and unresolved
+questions.

--- a/skills/generating-flow-diagrams/references/mermaid-style-guide.md
+++ b/skills/generating-flow-diagrams/references/mermaid-style-guide.md
@@ -36,6 +36,8 @@ classDef check fill:#e7f1ff,stroke:#0b5ed7,color:#000;
 classDef decision fill:#f8f9fa,stroke:#495057,color:#000;
 classDef human fill:#f3e8ff,stroke:#6f42c1,color:#000;
 classDef output fill:#e8f5e9,stroke:#2e7d32,color:#000;
+classDef success fill:#e8f5e9,stroke:#2e7d32,color:#000;
+classDef refine fill:#fff3cd,stroke:#856404,color:#000;
 classDef stop fill:#fdecea,stroke:#b02a37,color:#000;
 ```
 
@@ -44,7 +46,7 @@ classDef stop fill:#fdecea,stroke:#b02a37,color:#000;
 - Avoid lowercase `end` as a node label because it can terminate a subgraph.
 - Avoid node IDs that accidentally start a special edge form, such as `o` or `x` immediately after an edge marker.
 - Quote labels that contain punctuation likely to confuse Mermaid parsing.
-- Define every class before assigning it.
+- Prefer grouping `classDef` lines before assignments for readability; Mermaid validity does not depend on defining a class before assigning it.
 - Assign classes only to nodes that exist.
 - Avoid duplicate conflicting node definitions.
 - Prefer one edge per line when the flow is complex.
@@ -65,5 +67,7 @@ flowchart TD
   class CHECK,READY decision;
   class VALIDATE check;
   class REPORT output;
-  class BLOCKED,REFINE,DONE stop;
+  class DONE success;
+  class REFINE refine;
+  class BLOCKED stop;
 ```

--- a/skills/generating-flow-diagrams/references/mermaid-style-guide.md
+++ b/skills/generating-flow-diagrams/references/mermaid-style-guide.md
@@ -1,0 +1,69 @@
+# Mermaid Style Guide
+
+> Load this file when writing or repairing Mermaid. If current syntax details are
+> uncertain, fetch the Mermaid source listed in `external-sources.md`.
+
+## Default Diagram Type
+
+Use `flowchart TD` for process flows unless another Mermaid diagram type is
+clearly better. `TD` means top-down; `LR` can be used when a horizontal lifecycle
+is more readable.
+
+## Shape Conventions
+
+- Start and terminal states: rounded or stadium nodes.
+- Process steps: rectangle nodes.
+- Decisions: diamond nodes with named outcomes.
+- Human gates: distinct class and explicit approve or decline paths.
+- Outputs: distinct class and clear artifact name.
+
+## Labeling
+
+Use short, action-oriented node identifiers and readable labels, such as
+`COLLECT_CONTEXT`, `VERIFY_CLAIMS`, `ASK_HUMAN`, and `POST_REPORT`. Use `\n` or
+quoted labels when one short clarification is needed.
+
+Keep link labels explicit: `yes`, `no`, `approved`, `declined`, `blocked`,
+`needs research`, or another named outcome.
+
+## Class Definitions
+
+Use class definitions similar to this template:
+
+```mermaid
+classDef guard fill:#fff3cd,stroke:#856404,color:#000;
+classDef check fill:#e7f1ff,stroke:#0b5ed7,color:#000;
+classDef decision fill:#f8f9fa,stroke:#495057,color:#000;
+classDef human fill:#f3e8ff,stroke:#6f42c1,color:#000;
+classDef output fill:#e8f5e9,stroke:#2e7d32,color:#000;
+classDef stop fill:#fdecea,stroke:#b02a37,color:#000;
+```
+
+## Common Syntax Pitfalls
+
+- Avoid lowercase `end` as a node label because it can terminate a subgraph.
+- Avoid node IDs that accidentally start a special edge form, such as `o` or `x` immediately after an edge marker.
+- Quote labels that contain punctuation likely to confuse Mermaid parsing.
+- Define every class before assigning it.
+- Assign classes only to nodes that exist.
+- Avoid duplicate conflicting node definitions.
+- Prefer one edge per line when the flow is complex.
+
+## Minimal Pattern
+
+```mermaid
+flowchart TD
+  START([Start]) --> BOUNDARY[State authority and boundary]
+  BOUNDARY --> CHECK{Evidence available?}
+  CHECK -->|yes| VALIDATE[Run validation checks]
+  CHECK -->|no| BLOCKED([Blocked: missing evidence])
+  VALIDATE --> READY{Ready?}
+  READY -->|yes| REPORT[Draft output]
+  READY -->|no| REFINE([Needs refinement])
+  REPORT --> DONE([Ready])
+
+  class CHECK,READY decision;
+  class VALIDATE check;
+  class REPORT output;
+  class BLOCKED,REFINE,DONE stop;
+```

--- a/skills/generating-flow-diagrams/references/output-templates.md
+++ b/skills/generating-flow-diagrams/references/output-templates.md
@@ -1,0 +1,54 @@
+# Output Templates
+
+> Load this file only when assembling the user-facing pre-check or final diagram
+> output.
+
+## Refinement Pre-Check Template
+
+Use this when an existing flow has improvable gaps that need user approval before
+generation proceeds:
+
+```markdown
+## Refinement Pre-Check
+
+| Gap | Type | Why It Matters | Proposed Change |
+| --- | ---- | -------------- | --------------- |
+| ... | ... | ... | ... |
+
+Which gaps should I include or fix in the revised flow?
+```
+
+## Final Markdown Template
+
+````markdown
+# <PROCESS_NAME>
+
+<Short paragraph describing the workflow boundary, agent authority, trust model,
+allowed actions, forbidden actions, and mutation limits.>
+
+```mermaid
+flowchart TD
+  ...
+```
+
+```text
+Optional output/report/comment template, if useful.
+```
+
+Readiness rule: <optional completion or sensitive-action rule>
+````
+
+## Optional Report Template Pattern
+
+Include a report template only when it helps the workflow user act on the final
+state:
+
+```text
+Status: ready | blocked | needs refinement | deferred | escalated
+Evidence checked:
+Risks:
+Blockers:
+Recommendations:
+Unresolved questions:
+Human approvals required:
+```

--- a/skills/generating-flow-diagrams/references/output-templates.md
+++ b/skills/generating-flow-diagrams/references/output-templates.md
@@ -11,11 +11,12 @@ generation proceeds:
 ```markdown
 ## Refinement Pre-Check
 
-| Gap | Type | Why It Matters | Proposed Change |
-| --- | ---- | -------------- | --------------- |
-| ... | ... | ... | ... |
+| ID | Gap | Type | Why It Matters | Proposed Change |
+| -- | --- | ---- | -------------- | --------------- |
+| G1 | ... | ... | ... | ... |
 
-Which gaps should I include or fix in the revised flow?
+Which gap IDs should I include or fix in the revised flow? Reply with IDs like
+`G1, G3`, or `none`.
 ```
 
 ## Final Markdown Template

--- a/skills/generating-flow-diagrams/references/quality-gate-checklist.md
+++ b/skills/generating-flow-diagrams/references/quality-gate-checklist.md
@@ -1,7 +1,8 @@
 # Quality Gate Checklist
 
-> Load this file only when reviewing a candidate diagram or repairing failed
-> checks. Reject failed candidates and re-check only the failed areas.
+> Load this file only when reviewing a candidate diagram or preparing targeted
+> repair feedback. Failed checks guide the builder repair; the full reviewer
+> gate runs again after each repaired candidate.
 
 ## Review Checks
 
@@ -20,8 +21,8 @@
 ## Fix Loop
 
 1. Return `REVIEW: FAIL` with specific failed checks.
-2. Send only those failed checks to the builder.
-3. Re-run only the failed check group after repair.
+2. Send only those failed checks to the builder as `REVIEW_FEEDBACK`.
+3. After the builder repairs the candidate, run the full `diagram-quality-reviewer` checklist again against the updated candidate.
 4. Stop after three fix cycles for the same candidate.
 5. Escalate to the user if missing information or approval blocks a valid diagram.
 

--- a/skills/generating-flow-diagrams/references/quality-gate-checklist.md
+++ b/skills/generating-flow-diagrams/references/quality-gate-checklist.md
@@ -1,0 +1,32 @@
+# Quality Gate Checklist
+
+> Load this file only when reviewing a candidate diagram or repairing failed
+> checks. Reject failed candidates and re-check only the failed areas.
+
+## Review Checks
+
+| Check | Pass Condition |
+| ----- | -------------- |
+| Mermaid syntax | One fenced `mermaid` block; valid `flowchart` declaration; balanced brackets and quotes; no malformed arrows |
+| Classes | Classes are defined before use and assigned only to existing nodes |
+| Flow coverage | Intake, boundary, validation, synthesis, decisions, outputs, and terminal states are represented when relevant |
+| Human gates | Every sensitive action has approve and decline paths plus audit or handoff handling |
+| Branch integrity | Every branch has a destination; every decision has named outcomes |
+| Validation flow | Validation checks feed synthesis, readiness, blocker, refinement, research, or escalation paths |
+| Grounding | Unsupported facts are not presented as confirmed; assumptions and unknowns are labeled |
+| Refinement approval | Refinement output includes only user-approved gap fixes |
+| Output contract | Final Markdown has title, boundary paragraph, one Mermaid diagram, and optional templates/rules only when useful |
+
+## Fix Loop
+
+1. Return `REVIEW: FAIL` with specific failed checks.
+2. Send only those failed checks to the builder.
+3. Re-run only the failed check group after repair.
+4. Stop after three fix cycles for the same candidate.
+5. Escalate to the user if missing information or approval blocks a valid diagram.
+
+## Failure Severity
+
+- `high`: invalid Mermaid, missing human gate for sensitive action, unapproved refinement change, or missing terminal states.
+- `medium`: disconnected validation, unclear branch labels, unsupported assumptions, or missing output contract element.
+- `low`: style inconsistency, verbose labels, or optional template mismatch.

--- a/skills/generating-flow-diagrams/references/quality-gate-checklist.md
+++ b/skills/generating-flow-diagrams/references/quality-gate-checklist.md
@@ -8,7 +8,7 @@
 | Check | Pass Condition |
 | ----- | -------------- |
 | Mermaid syntax | One fenced `mermaid` block; valid `flowchart` declaration; balanced brackets and quotes; no malformed arrows |
-| Classes | Classes are defined before use and assigned only to existing nodes |
+| Classes | Class assignments target only existing nodes; `classDef` ordering does not determine validity |
 | Flow coverage | Intake, boundary, validation, synthesis, decisions, outputs, and terminal states are represented when relevant |
 | Human gates | Every sensitive action has approve and decline paths plus audit or handoff handling |
 | Branch integrity | Every branch has a destination; every decision has named outcomes |

--- a/skills/generating-flow-diagrams/subagents/diagram-builder.md
+++ b/skills/generating-flow-diagrams/subagents/diagram-builder.md
@@ -15,9 +15,12 @@ stop, and when a human must approve the next action.
 | Input | Required | Example |
 | ----- | -------- | ------- |
 | `PROCESS_INPUTS` | Yes | Required fields from `SKILL.md` |
-| `APPROVED_REFINEMENT_GAPS` | No | Gap names or rows approved by the user |
+| `CANDIDATE_MARKDOWN` | No | Current candidate from the failed review cycle |
+| `APPROVED_REFINEMENT_GAPS` | No | Gap IDs, names, or rows approved by the user |
 | `REVIEW_FEEDBACK` | No | Failed checks from `diagram-quality-reviewer` |
 | `RUN_MODE` | Yes | `new`, `refinement`, or `repair` |
+
+`CANDIDATE_MARKDOWN` and `REVIEW_FEEDBACK` are required when `RUN_MODE=repair`.
 
 ## Instructions
 
@@ -47,6 +50,12 @@ BUILD: PASS | NEEDS_INPUT | ERROR
 - Approved refinement gaps used: ...
 - Assumptions: ...
 - External sources fetched: ...
+
+## Failure Details
+Required for `NEEDS_INPUT` or `ERROR`; omit for `PASS`.
+- Missing input: ...
+- Failed condition: ...
+- Recovery action: ...
 ````
 
 ## Scope

--- a/skills/generating-flow-diagrams/subagents/diagram-builder.md
+++ b/skills/generating-flow-diagrams/subagents/diagram-builder.md
@@ -20,6 +20,8 @@ stop, and when a human must approve the next action.
 | `REVIEW_FEEDBACK` | No | Failed checks from `diagram-quality-reviewer` |
 | `RUN_MODE` | Yes | `new`, `refinement`, or `repair` |
 
+`APPROVED_REFINEMENT_GAPS` is required when `RUN_MODE=refinement`; if it is
+missing, empty, or ambiguous, return `BUILD: NEEDS_INPUT` with `Failure Details`.
 `CANDIDATE_MARKDOWN` and `REVIEW_FEEDBACK` are required when `RUN_MODE=repair`.
 
 ## Instructions
@@ -27,7 +29,7 @@ stop, and when a human must approve the next action.
 1. Load `../references/flow-design-playbook.md` for required flow content.
 2. Load `../references/mermaid-style-guide.md` for syntax, class, and style rules.
 3. Load `../references/output-templates.md` when assembling the final Markdown.
-4. For refinement runs, apply only the gaps approved by the user.
+4. For refinement runs, apply only the gaps approved by the user; return `BUILD: NEEDS_INPUT` when approved gap IDs are missing.
 5. For repair runs, change only the issues named in `REVIEW_FEEDBACK` unless a fix exposes a direct dependency.
 6. Keep facts, assumptions, risks, blockers, recommendations, and unresolved questions distinct.
 7. Return a complete candidate; do not claim it is final until review passes.

--- a/skills/generating-flow-diagrams/subagents/diagram-builder.md
+++ b/skills/generating-flow-diagrams/subagents/diagram-builder.md
@@ -1,0 +1,64 @@
+---
+name: "diagram-builder"
+description: "Builds or repairs the Markdown plus Mermaid flow-diagram candidate using approved scope, bundled references, and targeted review feedback."
+---
+
+# Diagram Builder
+
+You are a workflow diagram builder. Convert the approved process scope into a
+candidate Markdown document with one Mermaid diagram. Optimize for auditability:
+the reader should see what the agent may do, what it must verify, when it must
+stop, and when a human must approve the next action.
+
+## Inputs
+
+| Input | Required | Example |
+| ----- | -------- | ------- |
+| `PROCESS_INPUTS` | Yes | Required fields from `SKILL.md` |
+| `APPROVED_REFINEMENT_GAPS` | No | Gap names or rows approved by the user |
+| `REVIEW_FEEDBACK` | No | Failed checks from `diagram-quality-reviewer` |
+| `RUN_MODE` | Yes | `new`, `refinement`, or `repair` |
+
+## Instructions
+
+1. Load `../references/flow-design-playbook.md` for required flow content.
+2. Load `../references/mermaid-style-guide.md` for syntax, class, and style rules.
+3. Load `../references/output-templates.md` when assembling the final Markdown.
+4. For refinement runs, apply only the gaps approved by the user.
+5. For repair runs, change only the issues named in `REVIEW_FEEDBACK` unless a fix exposes a direct dependency.
+6. Keep facts, assumptions, risks, blockers, recommendations, and unresolved questions distinct.
+7. Return a complete candidate; do not claim it is final until review passes.
+
+Fetch from `../references/external-sources.md` only when local guidance is
+insufficient or the user asks for source-backed rationale.
+
+## Output Format
+
+````markdown
+BUILD: PASS | NEEDS_INPUT | ERROR
+
+## Candidate
+```markdown
+[Complete Markdown document with exactly one Mermaid block]
+```
+
+## Build Notes
+- Mode: new | refinement | repair
+- Approved refinement gaps used: ...
+- Assumptions: ...
+- External sources fetched: ...
+````
+
+## Scope
+
+Your job is to build or repair the candidate diagram. Leave independent quality
+review to `diagram-quality-reviewer`.
+
+## Escalation
+
+| Status | When |
+| ------ | ---- |
+| `NEEDS_INPUT` | Required process inputs or refinement approvals are missing |
+| `ERROR` | An unexpected generation or formatting failure occurs |
+
+For non-pass statuses, include the exact missing input or failed condition.

--- a/skills/generating-flow-diagrams/subagents/diagram-quality-reviewer.md
+++ b/skills/generating-flow-diagrams/subagents/diagram-quality-reviewer.md
@@ -1,0 +1,68 @@
+---
+name: "diagram-quality-reviewer"
+description: "Reviews a candidate Markdown plus Mermaid diagram for syntax validity, instruction coverage, approved refinement scope, and output contract compliance."
+---
+
+# Diagram Quality Reviewer
+
+You are a quality-gate reviewer. Your purpose is to reject invalid flow diagrams
+before they reach the user. Review the candidate against observable checks and
+return concise, targeted fixes.
+
+## Inputs
+
+| Input | Required | Example |
+| ----- | -------- | ------- |
+| `CANDIDATE_MARKDOWN` | Yes | Candidate from `diagram-builder` |
+| `PROCESS_INPUTS` | Yes | Required fields from `SKILL.md` |
+| `RUN_MODE` | Yes | `new`, `refinement`, or `repair` |
+| `APPROVED_REFINEMENT_GAPS` | Required for refinement | User-approved gap list |
+
+## Instructions
+
+1. Load `../references/quality-gate-checklist.md` before reviewing.
+2. Check Mermaid syntax plausibility, required flow coverage, human gates, branch integrity, terminal states, grounding, output shape, and refinement approval scope.
+3. Return `REVIEW: PASS` only when every applicable check passes.
+4. For failures, report the smallest repair needed and reference the specific check.
+5. Do not rewrite the candidate yourself.
+
+Fetch current Mermaid documentation through `../references/external-sources.md`
+only when syntax uncertainty affects the verdict.
+
+## Output Format
+
+```markdown
+REVIEW: PASS | FAIL | BLOCKED | ERROR
+
+## Findings
+| Severity | Check | Issue | Required Fix |
+| -------- | ----- | ----- | ------------ |
+
+## Checks
+- Mermaid syntax:
+- Required flow coverage:
+- Human gates:
+- Branch integrity:
+- Grounding:
+- Refinement approval:
+- Output contract:
+
+## Summary
+- Fix cycle needed: yes/no
+- Escalate to user: yes/no
+- Notes: ...
+```
+
+## Scope
+
+Your job is independent review. Return verdicts and targeted fixes, not a revised
+diagram.
+
+## Escalation
+
+| Status | When |
+| ------ | ---- |
+| `BLOCKED` | Candidate or required process inputs are missing |
+| `ERROR` | An unexpected validation failure prevents review |
+
+For `BLOCKED` or `ERROR`, include the exact missing input or validation blocker.

--- a/skills/generating-flow-diagrams/subagents/diagram-quality-reviewer.md
+++ b/skills/generating-flow-diagrams/subagents/diagram-quality-reviewer.md
@@ -16,7 +16,9 @@ return concise, targeted fixes.
 | `CANDIDATE_MARKDOWN` | Yes | Candidate from `diagram-builder` |
 | `PROCESS_INPUTS` | Yes | Required fields from `SKILL.md` |
 | `RUN_MODE` | Yes | `new`, `refinement`, or `repair` |
-| `APPROVED_REFINEMENT_GAPS` | Required for refinement | User-approved gap list |
+| `APPROVED_REFINEMENT_GAPS` | No | User-approved gap list for refinement |
+
+`APPROVED_REFINEMENT_GAPS` is required when `RUN_MODE=refinement`.
 
 ## Instructions
 
@@ -43,6 +45,8 @@ REVIEW: PASS | FAIL | BLOCKED | ERROR
 - Required flow coverage:
 - Human gates:
 - Branch integrity:
+- Validation flow:
+- Terminal states:
 - Grounding:
 - Refinement approval:
 - Output contract:

--- a/skills/generating-flow-diagrams/subagents/diagram-quality-reviewer.md
+++ b/skills/generating-flow-diagrams/subagents/diagram-quality-reviewer.md
@@ -23,7 +23,7 @@ return concise, targeted fixes.
 ## Instructions
 
 1. Load `../references/quality-gate-checklist.md` before reviewing.
-2. Check Mermaid syntax plausibility, required flow coverage, human gates, branch integrity, terminal states, grounding, output shape, and refinement approval scope.
+2. Check Mermaid syntax plausibility, classes, required flow coverage, human gates, branch integrity, terminal states, grounding, output shape, and refinement approval scope.
 3. Return `REVIEW: PASS` only when every applicable check passes.
 4. For failures, report the smallest repair needed and reference the specific check.
 5. Do not rewrite the candidate yourself.
@@ -42,6 +42,7 @@ REVIEW: PASS | FAIL | BLOCKED | ERROR
 
 ## Checks
 - Mermaid syntax:
+- Classes:
 - Required flow coverage:
 - Human gates:
 - Branch integrity:

--- a/skills/generating-flow-diagrams/subagents/diagram-quality-reviewer.md
+++ b/skills/generating-flow-diagrams/subagents/diagram-quality-reviewer.md
@@ -23,7 +23,7 @@ return concise, targeted fixes.
 ## Instructions
 
 1. Load `../references/quality-gate-checklist.md` before reviewing.
-2. Check Mermaid syntax plausibility, classes, required flow coverage, human gates, branch integrity, terminal states, grounding, output shape, and refinement approval scope.
+2. Check Mermaid syntax plausibility, classes, required flow coverage, human gates, branch integrity, validation flow, terminal states, grounding, output shape, and refinement approval scope.
 3. Return `REVIEW: PASS` only when every applicable check passes.
 4. For failures, report the smallest repair needed and reference the specific check.
 5. Do not rewrite the candidate yourself.

--- a/skills/generating-flow-diagrams/subagents/refinement-analyst.md
+++ b/skills/generating-flow-diagrams/subagents/refinement-analyst.md
@@ -1,0 +1,59 @@
+---
+name: "refinement-analyst"
+description: "Inspects an existing flow, Mermaid diagram, or process description and returns a concise gap inventory before the orchestrator asks the user which gaps to approve."
+---
+
+# Refinement Analyst
+
+You are a refinement pre-check specialist. Your job is to protect user intent by
+finding improvable gaps in an existing flow without rewriting the diagram or
+silently expanding scope.
+
+## Inputs
+
+| Input | Required | Example |
+| ----- | -------- | ------- |
+| `EXISTING_FLOW_OR_DIAGRAM` | Yes | Existing Mermaid block, file content, or process prose |
+| `REFINEMENT_REQUEST` | No | `Improve safety gates only` |
+| `PROCESS_CONTEXT` | No | Role, objective, allowed actions, forbidden actions, sensitive actions |
+
+## Instructions
+
+1. Inspect the existing flow or process description as source material.
+2. Identify only concrete gaps that the generation process could improve.
+3. Classify each gap as `structural`, `safety`, `evidence`, `syntax`, `scope`, `human-confirmation`, `output-shape`, or `completion-criteria`.
+4. Propose the smallest fix for each gap without applying it.
+5. If no meaningful gaps exist, return `PREFLIGHT: PASS`.
+6. If gaps exist, return `PREFLIGHT: NEEDS_CONFIRMATION` and a confirmation question.
+
+## Output Format
+
+```markdown
+PREFLIGHT: PASS | NEEDS_CONFIRMATION | BLOCKED | ERROR
+
+## Gap Inventory
+| Gap | Type | Why It Matters | Proposed Change |
+| --- | ---- | -------------- | --------------- |
+
+## Confirmation Question
+[One concise question asking which gaps are approved, or `none` for PASS.]
+
+## Summary
+- Existing flow usable as baseline: yes/no
+- Approved gaps already provided: yes/no
+- Notes: ...
+```
+
+## Scope
+
+Your job is to inspect, classify, and ask for approval. Leave diagram generation
+and repair to `diagram-builder`.
+
+## Escalation
+
+| Status | When |
+| ------ | ---- |
+| `BLOCKED` | The existing flow or process description is missing or unreadable |
+| `ERROR` | An unexpected tool or parsing failure prevents inspection |
+
+For `BLOCKED` or `ERROR`, include the smallest missing input or recovery action.

--- a/skills/generating-flow-diagrams/subagents/refinement-analyst.md
+++ b/skills/generating-flow-diagrams/subagents/refinement-analyst.md
@@ -23,8 +23,9 @@ silently expanding scope.
 2. Identify only concrete gaps that the generation process could improve.
 3. Classify each gap as `structural`, `safety`, `evidence`, `syntax`, `scope`, `human-confirmation`, `output-shape`, or `completion-criteria`.
 4. Propose the smallest fix for each gap without applying it.
-5. If no meaningful gaps exist, return `PREFLIGHT: PASS`.
-6. If gaps exist, return `PREFLIGHT: NEEDS_CONFIRMATION` and a confirmation question.
+5. Assign stable deterministic gap IDs in discovery order (`G1`, `G2`, `G3`).
+6. If no meaningful gaps exist, return `PREFLIGHT: PASS`.
+7. If gaps exist, return `PREFLIGHT: NEEDS_CONFIRMATION` and a confirmation question that asks which gap IDs are approved.
 
 ## Output Format
 
@@ -32,11 +33,11 @@ silently expanding scope.
 PREFLIGHT: PASS | NEEDS_CONFIRMATION | BLOCKED | ERROR
 
 ## Gap Inventory
-| Gap | Type | Why It Matters | Proposed Change |
-| --- | ---- | -------------- | --------------- |
+| ID | Gap | Type | Why It Matters | Proposed Change |
+| -- | --- | ---- | -------------- | --------------- |
 
 ## Confirmation Question
-[One concise question asking which gaps are approved, or `none` for PASS.]
+[One concise question asking which gap IDs are approved, or `none` for PASS.]
 
 ## Summary
 - Existing flow usable as baseline: yes/no


### PR DESCRIPTION
## Summary

Adds a new `generating-flow-diagrams` skill that turns AI-agent workflow descriptions into auditable Markdown documents with Mermaid flowcharts. The skill treats diagrams as operating contracts — exposing authority, evidence, validation, human gates, and terminal states — and delegates execution to focused subagents while keeping the orchestrator lean.

## Key Changes

- Adds `skills/generating-flow-diagrams/SKILL.md` as a routing orchestrator with progressive loading and a subagent registry.
- Adds three subagents: `refinement-analyst`, `diagram-builder`, and `diagram-quality-reviewer`.
- Adds five reference files: flow design playbook, Mermaid style guide, output templates, quality gate checklist, and external sources.
- Updates `README.md` skill catalog (27 → 28 first-party skills).

## Impact

- New standalone skill for creating or refining AI-agent workflow diagrams with human-in-the-loop gates and quality checks.
- No changes to existing skills or runtime configuration.
- No automated tests in this repo; verification is manual skill-structure review.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only adds new documentation/skill content and updates the README catalog, without modifying existing skills or any runtime logic.
> 
> **Overview**
> Adds a new first-party skill, `generating-flow-diagrams`, for producing or refining **auditable Markdown + Mermaid workflow diagrams** with explicit boundaries, evidence/validation steps, human confirmation gates for sensitive actions, and clear terminal states.
> 
> The skill introduces a progressive-disclosure orchestrator (`SKILL.md`), three dedicated subagents (`refinement-analyst`, `diagram-builder`, `diagram-quality-reviewer`), and bundled reference playbooks/templates (flow design guidance, Mermaid style rules, a quality-gate checklist, and optional external source links). The `README.md` catalog is updated to reflect 28 first-party skills and to list the new entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b3a1153398e2840068f5d95692aa1dd60a20a86. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->