### PR TITLE
fix(refine-task): align subagent paths and Ready to post flow

### DIFF
--- a/skills/refine-task/SKILL.md
+++ b/skills/refine-task/SKILL.md
@@ -36,7 +36,7 @@ for one source item.
 2. Dispatch refinement-reviewer with compact source pointers and user intent.
 3. Branch on the returned structured status.
 4. Post only when WRITE_MODE=post-comment, posting is available, and the reviewer returned POST_ALLOWED=yes.
-5. If the reviewer returns a postable comment that is not posted, return `Mode: Ready to post`; otherwise return the reviewer mode and comment.
+5. If the reviewer returns `Comment mode=Ready to post` and the coordinator does not post, return `Mode: Ready to post`; otherwise return the reviewer mode and comment.
 ```
 
 ## Subagent Registry
@@ -99,8 +99,8 @@ Comment: <final comment or draft>
 Use `Posted` only after the coordinator successfully posts the exact refinement
 comment returned by the reviewer.
 
-Use `Ready to post` when the reviewer returns a postable comment but the
-coordinator does not post it, such as draft or unknown write mode, or a safe
+Use `Ready to post` when the reviewer returns `Comment mode=Ready to post` but
+the coordinator does not post it, such as draft or unknown write mode, or a safe
 post-comment run where posting is not performed.
 
 If the reviewer reports a mutation-only request with no refinement review to

--- a/skills/refine-task/SKILL.md
+++ b/skills/refine-task/SKILL.md
@@ -36,7 +36,7 @@ for one source item.
 2. Dispatch refinement-reviewer with compact source pointers and user intent.
 3. Branch on the returned structured status.
 4. Post only when WRITE_MODE=post-comment, posting is available, and the reviewer returned POST_ALLOWED=yes.
-5. Otherwise return the reviewer comment as a draft.
+5. If the reviewer returns a postable comment that is not posted, return `Mode: Ready to post`; otherwise return the reviewer mode and comment.
 ```
 
 ## Subagent Registry
@@ -99,6 +99,10 @@ Comment: <final comment or draft>
 Use `Posted` only after the coordinator successfully posts the exact refinement
 comment returned by the reviewer.
 
+Use `Ready to post` when the reviewer returns a postable comment but the
+coordinator does not post it, such as draft or unknown write mode, or a safe
+post-comment run where posting is not performed.
+
 If the reviewer reports a mutation-only request with no refinement review to
 perform, return `Mode: Deferred` and explain that the mutation belongs in a
 separate approved workflow.
@@ -120,5 +124,5 @@ Input: `Review https://github.com/acme/app/issues/42 for readiness and draft a r
 
 Flow: normalize `ITEM_URL`, dispatch `refinement-reviewer` with
 `WRITE_MODE=draft`, receive `REVIEW_STATUS=Needs refinement` and
-`POST_ALLOWED=no`, then return the draft comment.
+`Comment mode=Draft`, then return the draft comment.
 </example>

--- a/skills/refine-task/SKILL.md
+++ b/skills/refine-task/SKILL.md
@@ -73,11 +73,11 @@ ITEM_URL: <input URL, if available>
 ITEM_CONTEXT: <compact pasted context or file path, if available>
 WRITE_MODE: draft | post-comment | unknown
 HUMAN_APPROVALS: <explicit approvals, if any>
-REVIEWER_POLICY_PATH: ./references/reviewer-policy.md
-REFINEMENT_CHECKS_PATH: ./references/refinement-checks.md
-COMMENT_TEMPLATE_PATH: ./references/comment-template.md
-QUALITY_CHECKLIST_PATH: ./references/review-quality-checklist.md
-EXTERNAL_SOURCES_PATH: ./references/external-sources.md
+REVIEWER_POLICY_PATH: ../references/reviewer-policy.md
+REFINEMENT_CHECKS_PATH: ../references/refinement-checks.md
+COMMENT_TEMPLATE_PATH: ../references/comment-template.md
+QUALITY_CHECKLIST_PATH: ../references/review-quality-checklist.md
+EXTERNAL_SOURCES_PATH: ../references/external-sources.md
 ```
 
 Keep only the returned `REVIEW_STATUS`, `POST_ALLOWED`, `Comment mode` (`Draft`,

--- a/skills/refine-task/SKILL.md
+++ b/skills/refine-task/SKILL.md
@@ -68,6 +68,9 @@ for the decision at hand.
 Dispatch `refinement-reviewer` with only the source pointers and decisions it
 needs:
 
+The reference paths in this dispatch block are relative to
+`subagents/refinement-reviewer.md`.
+
 ```text
 ITEM_URL: <input URL, if available>
 ITEM_CONTEXT: <compact pasted context or file path, if available>

--- a/skills/refine-task/SKILL.md
+++ b/skills/refine-task/SKILL.md
@@ -36,7 +36,7 @@ for one source item.
 2. Dispatch refinement-reviewer with compact source pointers and user intent.
 3. Branch on the returned structured status.
 4. Post only when WRITE_MODE=post-comment, posting is available, and the reviewer returned POST_ALLOWED=yes.
-5. If the reviewer returns `Comment mode=Ready to post` and the coordinator does not post, return `Mode: Ready to post`; otherwise return the reviewer mode and comment.
+5. If the reviewer returns `Comment mode=Ready to post` and the coordinator does not post, return `Mode: Ready to post`; otherwise return the reviewer Mode, Status, and Comment.
 ```
 
 ## Subagent Registry

--- a/skills/refine-task/flow-diagram.md
+++ b/skills/refine-task/flow-diagram.md
@@ -53,7 +53,7 @@ flowchart TD
   DRAFT_READY_MODE -->|no| DRAFT_OUT(["Draft: return Refinement review complete with Mode, Status, and Comment"])
   MODE_DECISION -->|post-comment requested| POST_ALLOWED_GATE{"POST_ALLOWED=yes?"}
   POST_ALLOWED_GATE -->|yes| POST_AVAILABLE{"Posting available?"}
-  POST_ALLOWED_GATE -->|no| RETURN_REVIEWER_MODE(["Return reviewer mode and final comment without posting"])
+  POST_ALLOWED_GATE -->|no| RETURN_REVIEWER_MODE(["Return reviewer Mode, Status, and Comment without posting"])
   POST_AVAILABLE -->|yes| POST_COMMENT["Post only the returned refinement comment"]
   POST_AVAILABLE -->|no| READY_TO_POST_OUT
   POST_COMMENT --> POSTED_OUT(["Posted: return Refinement review complete with Mode, Status, and Comment"])

--- a/skills/refine-task/flow-diagram.md
+++ b/skills/refine-task/flow-diagram.md
@@ -48,14 +48,15 @@ flowchart TD
   REVIEW_RETURN --> COORDINATOR_KEEP["Coordinator retains only verdict fields and final comment; keeps raw payloads and long analysis out of top-level context"]
   COORDINATOR_KEEP --> MODE_DECISION{"Output mode?"}
 
-  MODE_DECISION -->|draft or unknown| DRAFT_POSTABLE{"Reviewer says comment is postable?"}
-  DRAFT_POSTABLE -->|yes| READY_TO_POST_OUT(["Ready to post: return Refinement review complete with Mode, Status, and Comment"])
-  DRAFT_POSTABLE -->|no| DRAFT_OUT(["Draft: return Refinement review complete with Mode, Status, and Comment"])
-  MODE_DECISION -->|post-comment requested| POST_GATE{"POST_ALLOWED=yes and posting available?"}
-  POST_GATE -->|yes| POST_COMMENT["Post only the returned refinement comment"]
+  MODE_DECISION -->|draft or unknown| DRAFT_READY_MODE{"Comment mode=Ready to post?"}
+  DRAFT_READY_MODE -->|yes| READY_TO_POST_OUT(["Ready to post: return Refinement review complete with Mode, Status, and Comment"])
+  DRAFT_READY_MODE -->|no| DRAFT_OUT(["Draft: return Refinement review complete with Mode, Status, and Comment"])
+  MODE_DECISION -->|post-comment requested| POST_ALLOWED_GATE{"POST_ALLOWED=yes?"}
+  POST_ALLOWED_GATE -->|yes| POST_AVAILABLE{"Posting available?"}
+  POST_ALLOWED_GATE -->|no| BLOCKED_POST(["Blocked: do not post; return reason plus final comment draft"])
+  POST_AVAILABLE -->|yes| POST_COMMENT["Post only the returned refinement comment"]
+  POST_AVAILABLE -->|no| READY_TO_POST_OUT
   POST_COMMENT --> POSTED_OUT(["Posted: return Refinement review complete with Mode, Status, and Comment"])
-  POST_GATE -->|postable but not posted| READY_TO_POST_OUT
-  POST_GATE -->|no| BLOCKED_POST(["Blocked: do not post; return reason plus final comment draft"])
 
   classDef guard fill:#fff3cd,stroke:#856404,color:#000;
   classDef check fill:#e7f1ff,stroke:#0b5ed7,color:#000;
@@ -65,7 +66,7 @@ flowchart TD
   classDef refine fill:#fff3cd,stroke:#856404,color:#000;
   classDef stop fill:#fdecea,stroke:#b02a37,color:#000;
 
-  class SOURCE_AVAILABLE,MUTATION_ONLY,POSTING_CLARITY,ACCESS_OK,TECH_CLAIMS,SENSITIVE_REC,APPROVAL_AVAILABLE,QUALITY_PASS,MODE_DECISION,DRAFT_POSTABLE,POST_GATE decision;
+  class SOURCE_AVAILABLE,MUTATION_ONLY,POSTING_CLARITY,ACCESS_OK,TECH_CLAIMS,SENSITIVE_REC,APPROVAL_AVAILABLE,QUALITY_PASS,MODE_DECISION,DRAFT_READY_MODE,POST_ALLOWED_GATE,POST_AVAILABLE decision;
   class REVIEWER_POLICY,READINESS_CHECKS,VERIFY_CLAIMS,QUALITY_CHECK,FIX_CYCLE check;
   class ASK_SOURCE,ASK_POSTING,ASK_APPROVAL human;
   class INTAKE,WRITE_INTENT,COLLECT_POINTERS,DISPATCH,CLASSIFY,ASSEMBLE_COMMENT,REVIEW_RETURN,COORDINATOR_KEEP,INCLUDE_REC,NEUTRALIZE_REC,POST_COMMENT guard;

--- a/skills/refine-task/flow-diagram.md
+++ b/skills/refine-task/flow-diagram.md
@@ -53,7 +53,7 @@ flowchart TD
   DRAFT_READY_MODE -->|no| DRAFT_OUT(["Draft: return Refinement review complete with Mode, Status, and Comment"])
   MODE_DECISION -->|post-comment requested| POST_ALLOWED_GATE{"POST_ALLOWED=yes?"}
   POST_ALLOWED_GATE -->|yes| POST_AVAILABLE{"Posting available?"}
-  POST_ALLOWED_GATE -->|no| BLOCKED_POST(["Blocked: do not post; return reason plus final comment draft"])
+  POST_ALLOWED_GATE -->|no| RETURN_REVIEWER_MODE(["Return reviewer mode and final comment without posting"])
   POST_AVAILABLE -->|yes| POST_COMMENT["Post only the returned refinement comment"]
   POST_AVAILABLE -->|no| READY_TO_POST_OUT
   POST_COMMENT --> POSTED_OUT(["Posted: return Refinement review complete with Mode, Status, and Comment"])
@@ -70,9 +70,9 @@ flowchart TD
   class REVIEWER_POLICY,READINESS_CHECKS,VERIFY_CLAIMS,QUALITY_CHECK,FIX_CYCLE check;
   class ASK_SOURCE,ASK_POSTING,ASK_APPROVAL human;
   class INTAKE,WRITE_INTENT,COLLECT_POINTERS,DISPATCH,CLASSIFY,ASSEMBLE_COMMENT,REVIEW_RETURN,COORDINATOR_KEEP,INCLUDE_REC,NEUTRALIZE_REC,POST_COMMENT guard;
-  class DRAFT_OUT,READY_TO_POST_OUT,POSTED_OUT output;
+  class DRAFT_OUT,READY_TO_POST_OUT,POSTED_OUT,RETURN_REVIEWER_MODE output;
   class DEFER_MUTATION refine;
-  class BLOCKED_SOURCE,BLOCKED_POSTING,BLOCKED_ACCESS,BLOCKED_POST stop;
+  class BLOCKED_SOURCE,BLOCKED_POSTING,BLOCKED_ACCESS stop;
 ```
 
 Readiness rule: the workflow completes only as `Draft`, `Ready to post`, `Posted`, `Blocked`, or `Deferred` after the reviewer returns a compact verdict and final comment, quality validation passes or safe failure handling is reported, and the coordinator returns only retained verdict fields plus the final comment. Posting requires explicit posting intent, available tooling, and `POST_ALLOWED=yes`; otherwise the coordinator must not mutate the tracker.

--- a/skills/refine-task/flow-diagram.md
+++ b/skills/refine-task/flow-diagram.md
@@ -48,10 +48,13 @@ flowchart TD
   REVIEW_RETURN --> COORDINATOR_KEEP["Coordinator retains only verdict fields and final comment; keeps raw payloads and long analysis out of top-level context"]
   COORDINATOR_KEEP --> MODE_DECISION{"Output mode?"}
 
-  MODE_DECISION -->|draft or unknown| DRAFT_OUT(["Draft: return Refinement review complete with Mode, Status, and Comment"])
+  MODE_DECISION -->|draft or unknown| DRAFT_POSTABLE{"Reviewer says comment is postable?"}
+  DRAFT_POSTABLE -->|yes| READY_TO_POST_OUT(["Ready to post: return Refinement review complete with Mode, Status, and Comment"])
+  DRAFT_POSTABLE -->|no| DRAFT_OUT(["Draft: return Refinement review complete with Mode, Status, and Comment"])
   MODE_DECISION -->|post-comment requested| POST_GATE{"POST_ALLOWED=yes and posting available?"}
   POST_GATE -->|yes| POST_COMMENT["Post only the returned refinement comment"]
   POST_COMMENT --> POSTED_OUT(["Posted: return Refinement review complete with Mode, Status, and Comment"])
+  POST_GATE -->|postable but not posted| READY_TO_POST_OUT
   POST_GATE -->|no| BLOCKED_POST(["Blocked: do not post; return reason plus final comment draft"])
 
   classDef guard fill:#fff3cd,stroke:#856404,color:#000;
@@ -62,13 +65,13 @@ flowchart TD
   classDef refine fill:#fff3cd,stroke:#856404,color:#000;
   classDef stop fill:#fdecea,stroke:#b02a37,color:#000;
 
-  class SOURCE_AVAILABLE,MUTATION_ONLY,POSTING_CLARITY,ACCESS_OK,TECH_CLAIMS,SENSITIVE_REC,APPROVAL_AVAILABLE,QUALITY_PASS,MODE_DECISION,POST_GATE decision;
+  class SOURCE_AVAILABLE,MUTATION_ONLY,POSTING_CLARITY,ACCESS_OK,TECH_CLAIMS,SENSITIVE_REC,APPROVAL_AVAILABLE,QUALITY_PASS,MODE_DECISION,DRAFT_POSTABLE,POST_GATE decision;
   class REVIEWER_POLICY,READINESS_CHECKS,VERIFY_CLAIMS,QUALITY_CHECK,FIX_CYCLE check;
   class ASK_SOURCE,ASK_POSTING,ASK_APPROVAL human;
   class INTAKE,WRITE_INTENT,COLLECT_POINTERS,DISPATCH,CLASSIFY,ASSEMBLE_COMMENT,REVIEW_RETURN,COORDINATOR_KEEP,INCLUDE_REC,NEUTRALIZE_REC,POST_COMMENT guard;
-  class DRAFT_OUT,POSTED_OUT output;
+  class DRAFT_OUT,READY_TO_POST_OUT,POSTED_OUT output;
   class DEFER_MUTATION refine;
   class BLOCKED_SOURCE,BLOCKED_POSTING,BLOCKED_ACCESS,BLOCKED_POST stop;
 ```
 
-Readiness rule: the workflow completes only as `Draft`, `Posted`, `Blocked`, or `Deferred` after the reviewer returns a compact verdict and final comment, quality validation passes or safe failure handling is reported, and the coordinator returns only retained verdict fields plus the final comment. Posting requires explicit posting intent, available tooling, and `POST_ALLOWED=yes`; otherwise the coordinator must not mutate the tracker.
+Readiness rule: the workflow completes only as `Draft`, `Ready to post`, `Posted`, `Blocked`, or `Deferred` after the reviewer returns a compact verdict and final comment, quality validation passes or safe failure handling is reported, and the coordinator returns only retained verdict fields plus the final comment. Posting requires explicit posting intent, available tooling, and `POST_ALLOWED=yes`; otherwise the coordinator must not mutate the tracker.

--- a/skills/refine-task/references/reviewer-policy.md
+++ b/skills/refine-task/references/reviewer-policy.md
@@ -16,7 +16,7 @@ recommendations are not permission to perform tracker changes.
 | Outcome | Meaning |
 | ------- | ------- |
 | `Draft` | Return a comment body for the user to review or post manually. |
-| `Ready to post` | Coordinator may post exactly the refinement comment if posting is explicitly requested and available. |
+| `Ready to post` | The comment is safe to post exactly as returned; the coordinator may post it only when posting is explicitly requested and available, otherwise it returns this mode without mutating the tracker. |
 | `Blocked` | Review cannot proceed safely because source context, access, or authorization is missing. |
 | `Deferred` | User requested a tracker mutation that belongs in a separate approved workflow. |
 

--- a/skills/refine-task/subagents/refinement-reviewer.md
+++ b/skills/refine-task/subagents/refinement-reviewer.md
@@ -23,16 +23,17 @@ comment.
 | `ITEM_CONTEXT` | Optional | Pasted issue content, comments, linked context summary, or file path |
 | `WRITE_MODE` | Optional | `draft`, `post-comment`, or unknown |
 | `HUMAN_APPROVALS` | Optional | Explicit approvals for sensitive recommendations |
-| `REVIEWER_POLICY_PATH` | Yes | `./references/reviewer-policy.md` |
-| `REFINEMENT_CHECKS_PATH` | Yes | `./references/refinement-checks.md` |
-| `COMMENT_TEMPLATE_PATH` | Yes | `./references/comment-template.md` |
-| `QUALITY_CHECKLIST_PATH` | Yes | `./references/review-quality-checklist.md` |
-| `EXTERNAL_SOURCES_PATH` | Yes | `./references/external-sources.md` |
+| `REVIEWER_POLICY_PATH` | Yes | `../references/reviewer-policy.md` |
+| `REFINEMENT_CHECKS_PATH` | Yes | `../references/refinement-checks.md` |
+| `COMMENT_TEMPLATE_PATH` | Yes | `../references/comment-template.md` |
+| `QUALITY_CHECKLIST_PATH` | Yes | `../references/review-quality-checklist.md` |
+| `EXTERNAL_SOURCES_PATH` | Yes | `../references/external-sources.md` |
 
 If both `ITEM_URL` and usable `ITEM_CONTEXT` are missing, return `REVIEW: BLOCKED`
 with one request for the source item.
 
-Reference paths are skill-root-relative and are supplied by the coordinator.
+Reference paths are relative to this subagent file and are supplied by the
+coordinator.
 
 ## Instructions
 

--- a/skills/refine-task/subagents/refinement-reviewer.md
+++ b/skills/refine-task/subagents/refinement-reviewer.md
@@ -82,8 +82,9 @@ is exactly posting a refinement comment, and no unresolved mutation or safety
 gate prevents posting. This subagent does not post; it reports whether posting is
 allowed for the coordinator.
 
-Use `Comment mode=Ready to post` for a postable refinement comment,
-`Comment mode=Blocked` when review cannot proceed safely, and
+Use `Comment mode=Ready to post` for a refinement comment that is safe to post
+exactly as returned, `Comment mode=Draft` when the comment needs user review
+before posting, `Comment mode=Blocked` when review cannot proceed safely, and
 `Comment mode=Deferred` when the request belongs in a separate approved workflow.
 
 ## Scope


### PR DESCRIPTION
## Summary

This branch fixes the refine-task skill so subagent dispatch uses paths relative to each subagent file (not the skill root), and clarifies when the orchestrator should return **Ready to post** versus **Draft** when a comment is postable but not posted.

## Key Changes

- Updates `SKILL.md` and `refinement-reviewer.md` reference paths from `./references/...` to `../references/...`.
- Documents **Ready to post** in the orchestrator workflow, flow diagram, and reviewer policy.
- Distinguishes **Draft** vs **Ready to post** in reviewer comment modes and coordinator output rules.

## Impact

- Consumers of refine-task get correct progressive-disclosure paths when subagents load references.
- Non-posting runs with postable comments surface **Ready to post** instead of implying a draft-only outcome.
- No runtime or API changes; skill documentation only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only updates that adjust dispatch reference paths and tighten the coordinator/reviewer contract; main risk is behavior drift for consumers that follow the spec around `Ready to post` vs `Draft`.
> 
> **Overview**
> Clarifies the `refine-task` coordinator/reviewer contract so a postable (but not posted) refinement comment returns **`Mode: Ready to post`** instead of always defaulting to `Draft`, and updates the flow diagram and reviewer policy to match.
> 
> Aligns subagent dispatch reference paths from `./references/...` to `../references/...` (relative to `subagents/refinement-reviewer.md`) and expands `Comment mode` guidance to explicitly distinguish `Draft` vs `Ready to post`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 763e5f7c58e2b73abd52b2bfdb905eadb6998002. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->