### PR TITLE
fix(review-pull-request): support summary-only posting and add workflow flowchart

### DIFF
--- a/skills/review-pull-request/SKILL.md
+++ b/skills/review-pull-request/SKILL.md
@@ -47,7 +47,7 @@ inside the subagent that fetched them.
 | `comment-drafter` | `./subagents/comment-drafter.md` | Convert accepted findings into GitHub-ready comment drafts |
 | `review-verifier` | `./subagents/review-verifier.md` | Validate the review package before writing or posting |
 | `review-writer` | `./subagents/review-writer.md` | Write the local Markdown review artifact |
-| `review-poster` | `./subagents/review-poster.md` | Post only exact, approved, verified comments |
+| `review-poster` | `./subagents/review-poster.md` | Post only the exact, approved, verified review |
 
 Read a subagent file only when dispatching that phase.
 

--- a/skills/review-pull-request/flow-diagram.md
+++ b/skills/review-pull-request/flow-diagram.md
@@ -1,0 +1,4 @@
+# Review Pull Request Skill Flow
+
+This workflow reviews exactly one pull request at a time. The orchestrator may normalize inputs, collect PR context through subagents, coordinate review phases, verify findings before they become final, write a local Markdown review artifact, and post to GitHub only after an exact preview and explicit user approval. Raw diffs, logs, API payloads, large source content, and other high-volume evidence stay inside phase subagents.
+

--- a/skills/review-pull-request/flow-diagram.md
+++ b/skills/review-pull-request/flow-diagram.md
@@ -68,4 +68,19 @@ flowchart TD
   POST --> POST_STATUS{"POST status"}
   POST_STATUS -->|POST: PASS| SUCCESS_POSTED([Success: verified review posted to GitHub])
   POST_STATUS -->|post error| FAIL_POST([Terminal: post error])
+
+  class ONE_PR,CHOSEN,LARGE,PROCEED,CONTEXT_STATUS,FINDINGS_STATUS,RETRY_FINDINGS_STATUS,VERIFY_ROUTE,COMMENTS_STATUS,RETRY_COMMENTS_STATUS,VERIFY_STATUS,REPAIR_GATE,WRITE_STATUS,POST_MODE,APPROVED,POST_STATUS decision;
+  class PLAYBOOK,CONTEXT,FINDINGS,COMMENTS,VERIFY,WRITE,POST,NARROW_CONTEXT,RETRY_FINDINGS,COLLECT_METADATA,RETRY_COMMENTS,REPAIR check;
+  class ASK_PR,ASK_PROCEED,APPROVAL human;
+  class LOCAL_REVIEW,PREVIEW output;
+  class SUCCESS_DRAFT,SUCCESS_POSTED success;
+  class FAIL_INPUT,CANCELLED,FAIL_LARGE,FAIL_CONTEXT,FAIL_CONTEXT2,FAIL_FINDINGS,FAIL_COMMENTS,FAIL_VERIFY,FAIL_WRITE,FAIL_POST stop;
+  classDef guard fill:#fff3cd,stroke:#856404,color:#000;
+  classDef check fill:#e7f1ff,stroke:#0b5ed7,color:#000;
+  classDef decision fill:#f8f9fa,stroke:#495057,color:#000;
+  classDef human fill:#f3e8ff,stroke:#6f42c1,color:#000;
+  classDef output fill:#e8f5e9,stroke:#2e7d32,color:#000;
+  classDef success fill:#e8f5e9,stroke:#2e7d32,color:#000;
+  classDef refine fill:#fff3cd,stroke:#856404,color:#000;
+  classDef stop fill:#fdecea,stroke:#b02a37,color:#000;
 ```

--- a/skills/review-pull-request/flow-diagram.md
+++ b/skills/review-pull-request/flow-diagram.md
@@ -84,3 +84,15 @@ flowchart TD
   classDef refine fill:#fff3cd,stroke:#856404,color:#000;
   classDef stop fill:#fdecea,stroke:#b02a37,color:#000;
 ```
+
+Readiness rule: the review is ready only after `review-verifier` returns `VERIFY: PASS` and `review-writer` returns `WRITE: PASS`. Posting is never implicit; it requires `POSTING_MODE=post-after-confirmation`, an exact preview of the verified review file, and explicit final user approval.
+
+Status report shape:
+
+```text
+Review file:
+Findings count:
+Review decision:
+Posting state:
+Notes:
+```

--- a/skills/review-pull-request/flow-diagram.md
+++ b/skills/review-pull-request/flow-diagram.md
@@ -29,7 +29,7 @@ flowchart TD
   FINDINGS --> FINDINGS_STATUS{"FINDINGS status"}
   FINDINGS_STATUS -->|FINDINGS: PASS| COMMENTS["Dispatch comment-drafter"]
   FINDINGS_STATUS -->|FINDINGS: NO_FINDINGS| VERIFY["Dispatch review-verifier"]
-  FINDINGS_STATUS -->|FINDINGS: NEEDS_CONTEXT| NARROW_CONTEXT["Dispatch context collector once with narrow request"]
+  FINDINGS_STATUS -->|FINDINGS: NEEDS_CONTEXT| NARROW_CONTEXT["Dispatch pr-context-collector once with narrow request"]
   NARROW_CONTEXT --> RETRY_FINDINGS["Retry finding-reviewer once"]
   RETRY_FINDINGS --> RETRY_FINDINGS_STATUS{"Retry findings status"}
   RETRY_FINDINGS_STATUS -->|pass or no findings| VERIFY_ROUTE{"Findings found?"}

--- a/skills/review-pull-request/flow-diagram.md
+++ b/skills/review-pull-request/flow-diagram.md
@@ -2,3 +2,70 @@
 
 This workflow reviews exactly one pull request at a time. The orchestrator may normalize inputs, collect PR context through subagents, coordinate review phases, verify findings before they become final, write a local Markdown review artifact, and post to GitHub only after an exact preview and explicit user approval. Raw diffs, logs, API payloads, large source content, and other high-volume evidence stay inside phase subagents.
 
+```mermaid
+flowchart TD
+  START([Start: review one pull request]) --> INPUTS["Receive PR_URL and optional OUTPUT_FILE, POSTING_MODE, LANGUAGE_STYLE, REVIEW_FOCUS"]
+  INPUTS --> ONE_PR{"Exactly one PR URL?"}
+  ONE_PR -->|multiple| ASK_PR["Ask user to choose one PR"]
+  ASK_PR --> CHOSEN{"Single PR chosen?"}
+  CHOSEN -->|yes| NORMALIZE["Normalize inputs and default POSTING_MODE to draft-only"]
+  CHOSEN -->|cancelled| CANCELLED([Terminal: cancelled])
+  ONE_PR -->|yes| NORMALIZE
+  ONE_PR -->|none| FAIL_INPUT([Terminal: needs context])
+
+  NORMALIZE --> PLAYBOOK["Load review-workflow-playbook.md"]
+  PLAYBOOK --> LARGE{"Large review requires proceed confirmation?"}
+  LARGE -->|yes| ASK_PROCEED["Ask user whether to proceed"]
+  ASK_PROCEED --> PROCEED{"Proceed approved?"}
+  PROCEED -->|no| FAIL_LARGE([Terminal: large review not approved])
+  PROCEED -->|yes| CONTEXT["Dispatch pr-context-collector"]
+  LARGE -->|no| CONTEXT
+
+  CONTEXT --> CONTEXT_STATUS{"CONTEXT status"}
+  CONTEXT_STATUS -->|CONTEXT: PASS| FINDINGS["Dispatch finding-reviewer"]
+  CONTEXT_STATUS -->|auth or not found| FAIL_CONTEXT([Terminal: auth or not found])
+  CONTEXT_STATUS -->|needs context or error| FAIL_CONTEXT2([Terminal: needs context or review error])
+
+  FINDINGS --> FINDINGS_STATUS{"FINDINGS status"}
+  FINDINGS_STATUS -->|FINDINGS: PASS| COMMENTS["Dispatch comment-drafter"]
+  FINDINGS_STATUS -->|FINDINGS: NO_FINDINGS| VERIFY["Dispatch review-verifier"]
+  FINDINGS_STATUS -->|FINDINGS: NEEDS_CONTEXT| NARROW_CONTEXT["Dispatch context collector once with narrow request"]
+  NARROW_CONTEXT --> RETRY_FINDINGS["Retry finding-reviewer once"]
+  RETRY_FINDINGS --> RETRY_FINDINGS_STATUS{"Retry findings status"}
+  RETRY_FINDINGS_STATUS -->|pass or no findings| VERIFY_ROUTE{"Findings found?"}
+  VERIFY_ROUTE -->|yes| COMMENTS
+  VERIFY_ROUTE -->|no| VERIFY
+  RETRY_FINDINGS_STATUS -->|still blocked or error| FAIL_FINDINGS([Terminal: needs context or review error])
+  FINDINGS_STATUS -->|error| FAIL_FINDINGS
+
+  COMMENTS --> COMMENTS_STATUS{"COMMENTS status"}
+  COMMENTS_STATUS -->|COMMENTS: PASS| VERIFY
+  COMMENTS_STATUS -->|COMMENTS: NEEDS_METADATA| COLLECT_METADATA["Collect requested metadata once"]
+  COLLECT_METADATA --> RETRY_COMMENTS["Retry comment-drafter once"]
+  RETRY_COMMENTS --> RETRY_COMMENTS_STATUS{"Retry comments status"}
+  RETRY_COMMENTS_STATUS -->|COMMENTS: PASS| VERIFY
+  RETRY_COMMENTS_STATUS -->|still blocked or error| FAIL_COMMENTS([Terminal: review error])
+  COMMENTS_STATUS -->|error| FAIL_COMMENTS
+
+  VERIFY --> VERIFY_STATUS{"VERIFY status"}
+  VERIFY_STATUS -->|VERIFY: PASS| WRITE["Dispatch review-writer"]
+  VERIFY_STATUS -->|VERIFY: FAIL| REPAIR_GATE{"Repair cycles fewer than two?"}
+  REPAIR_GATE -->|yes| REPAIR["Repair only verifier-named Fix target phase"]
+  REPAIR --> VERIFY
+  REPAIR_GATE -->|no| FAIL_VERIFY([Terminal: verify fail])
+
+  WRITE --> WRITE_STATUS{"WRITE status"}
+  WRITE_STATUS -->|WRITE: PASS| LOCAL_REVIEW["Write verified local Markdown review file"]
+  WRITE_STATUS -->|write error| FAIL_WRITE([Terminal: write error])
+
+  LOCAL_REVIEW --> PREVIEW["Show exact file preview and report findings count, decision, posting state, notes"]
+  PREVIEW --> POST_MODE{"POSTING_MODE is post-after-confirmation?"}
+  POST_MODE -->|no, draft-only| SUCCESS_DRAFT([Success: verified draft saved locally])
+  POST_MODE -->|yes| APPROVAL["Ask for explicit final approval to post exact verified review"]
+  APPROVAL --> APPROVED{"Posting approved?"}
+  APPROVED -->|declined| SUCCESS_DRAFT
+  APPROVED -->|approved| POST["Dispatch review-poster"]
+  POST --> POST_STATUS{"POST status"}
+  POST_STATUS -->|POST: PASS| SUCCESS_POSTED([Success: verified review posted to GitHub])
+  POST_STATUS -->|post error| FAIL_POST([Terminal: post error])
+```

--- a/skills/review-pull-request/flow-diagram.md
+++ b/skills/review-pull-request/flow-diagram.md
@@ -58,7 +58,7 @@ flowchart TD
   WRITE_STATUS -->|WRITE: PASS| LOCAL_REVIEW["Confirm verified local Markdown review file"]
   WRITE_STATUS -->|write error| FAIL_WRITE([Terminal: write error])
 
-  LOCAL_REVIEW --> PREVIEW["Show exact file preview and report findings count, decision, posting state, notes"]
+  LOCAL_REVIEW --> PREVIEW["Show exact file preview and report Review file, Findings, Review decision, Posting, Notes"]
   PREVIEW --> POST_MODE{"POSTING_MODE is post-after-confirmation?"}
   POST_MODE -->|no, draft-only| SUCCESS_DRAFT([Success: verified draft saved locally])
   POST_MODE -->|yes| APPROVAL["Ask for explicit final approval to post exact verified review"]
@@ -89,8 +89,8 @@ Status report shape:
 
 ```text
 Review file:
-Findings count:
+Findings:
 Review decision:
-Posting state:
+Posting:
 Notes:
 ```

--- a/skills/review-pull-request/flow-diagram.md
+++ b/skills/review-pull-request/flow-diagram.md
@@ -14,15 +14,15 @@ flowchart TD
   ONE_PR -->|none| FAIL_INPUT([Terminal: needs context])
 
   NORMALIZE --> PLAYBOOK["Load review-workflow-playbook.md"]
-  PLAYBOOK --> LARGE{"Large review requires proceed confirmation?"}
-  LARGE -->|yes| ASK_PROCEED["Ask user whether to proceed"]
-  ASK_PROCEED --> PROCEED{"Proceed approved?"}
-  PROCEED -->|no| FAIL_LARGE([Terminal: large review not approved])
-  PROCEED -->|yes| CONTEXT["Dispatch pr-context-collector"]
-  LARGE -->|no| CONTEXT
+  PLAYBOOK --> CONTEXT["Dispatch pr-context-collector"]
 
   CONTEXT --> CONTEXT_STATUS{"CONTEXT status"}
   CONTEXT_STATUS -->|CONTEXT: PASS| FINDINGS["Dispatch finding-reviewer"]
+  CONTEXT_STATUS -->|CONTEXT: LARGE_REVIEW_CONFIRMATION_REQUIRED| ASK_PROCEED["Ask user whether to proceed with large review"]
+  ASK_PROCEED --> PROCEED{"Proceed approved?"}
+  PROCEED -->|no| FAIL_LARGE([Terminal: large review not approved])
+  PROCEED -->|yes| CONTEXT_APPROVED["Dispatch pr-context-collector with LARGE_REVIEW_APPROVED=true"]
+  CONTEXT_APPROVED --> CONTEXT_STATUS
   CONTEXT_STATUS -->|auth or not found| FAIL_CONTEXT([Terminal: auth or not found])
   CONTEXT_STATUS -->|needs context or error| FAIL_CONTEXT2([Terminal: needs context or review error])
 
@@ -69,8 +69,8 @@ flowchart TD
   POST_STATUS -->|POST: PASS| SUCCESS_POSTED([Success: verified review posted to GitHub])
   POST_STATUS -->|post error| FAIL_POST([Terminal: post error])
 
-  class ONE_PR,CHOSEN,LARGE,PROCEED,CONTEXT_STATUS,FINDINGS_STATUS,RETRY_FINDINGS_STATUS,VERIFY_ROUTE,COMMENTS_STATUS,RETRY_COMMENTS_STATUS,VERIFY_STATUS,REPAIR_GATE,WRITE_STATUS,POST_MODE,APPROVED,POST_STATUS decision;
-  class PLAYBOOK,CONTEXT,FINDINGS,COMMENTS,VERIFY,WRITE,POST,NARROW_CONTEXT,RETRY_FINDINGS,COLLECT_METADATA,RETRY_COMMENTS,REPAIR check;
+  class ONE_PR,CHOSEN,PROCEED,CONTEXT_STATUS,FINDINGS_STATUS,RETRY_FINDINGS_STATUS,VERIFY_ROUTE,COMMENTS_STATUS,RETRY_COMMENTS_STATUS,VERIFY_STATUS,REPAIR_GATE,WRITE_STATUS,POST_MODE,APPROVED,POST_STATUS decision;
+  class PLAYBOOK,CONTEXT,CONTEXT_APPROVED,FINDINGS,COMMENTS,VERIFY,WRITE,POST,NARROW_CONTEXT,RETRY_FINDINGS,COLLECT_METADATA,RETRY_COMMENTS,REPAIR check;
   class ASK_PR,ASK_PROCEED,APPROVAL human;
   class LOCAL_REVIEW,PREVIEW output;
   class SUCCESS_DRAFT,SUCCESS_POSTED success;

--- a/skills/review-pull-request/flow-diagram.md
+++ b/skills/review-pull-request/flow-diagram.md
@@ -55,7 +55,7 @@ flowchart TD
   REPAIR_GATE -->|no| FAIL_VERIFY([Terminal: verify fail])
 
   WRITE --> WRITE_STATUS{"WRITE status"}
-  WRITE_STATUS -->|WRITE: PASS| LOCAL_REVIEW["Write verified local Markdown review file"]
+  WRITE_STATUS -->|WRITE: PASS| LOCAL_REVIEW["Confirm verified local Markdown review file"]
   WRITE_STATUS -->|write error| FAIL_WRITE([Terminal: write error])
 
   LOCAL_REVIEW --> PREVIEW["Show exact file preview and report findings count, decision, posting state, notes"]

--- a/skills/review-pull-request/flow-diagram.md
+++ b/skills/review-pull-request/flow-diagram.md
@@ -75,13 +75,11 @@ flowchart TD
   class LOCAL_REVIEW,PREVIEW output;
   class SUCCESS_DRAFT,SUCCESS_POSTED success;
   class FAIL_INPUT,CANCELLED,FAIL_LARGE,FAIL_CONTEXT,FAIL_CONTEXT2,FAIL_FINDINGS,FAIL_COMMENTS,FAIL_VERIFY,FAIL_WRITE,FAIL_POST stop;
-  classDef guard fill:#fff3cd,stroke:#856404,color:#000;
   classDef check fill:#e7f1ff,stroke:#0b5ed7,color:#000;
   classDef decision fill:#f8f9fa,stroke:#495057,color:#000;
   classDef human fill:#f3e8ff,stroke:#6f42c1,color:#000;
   classDef output fill:#e8f5e9,stroke:#2e7d32,color:#000;
   classDef success fill:#e8f5e9,stroke:#2e7d32,color:#000;
-  classDef refine fill:#fff3cd,stroke:#856404,color:#000;
   classDef stop fill:#fdecea,stroke:#b02a37,color:#000;
 ```
 

--- a/skills/review-pull-request/subagents/review-poster.md
+++ b/skills/review-pull-request/subagents/review-poster.md
@@ -33,9 +33,9 @@ Posting is available only when `PREVIEW_APPROVED=true`.
    has `path`, `line`, `side`, and any required `start_line` or `start_side`
    before posting. Return the metadata-invalid status when fields are
    incomplete.
-4. Post comments with the exact bodies and metadata from `VERIFIED_COMMENTS`, or
-   post the approved summary review with zero comments for summary-only/no-
-   finding reviews.
+4. Post comments with the exact bodies and metadata from `VERIFIED_COMMENTS`.
+   For summary-only/no-finding reviews, read `OUTPUT_FILE` and post the
+   approved review body from that file with zero comments.
 5. Read back the created review or comments through the API or CLI and confirm
    they are visible.
 6. Before returning, load `../references/status-review-poster.md` and use that

--- a/skills/review-pull-request/subagents/review-poster.md
+++ b/skills/review-pull-request/subagents/review-poster.md
@@ -1,13 +1,14 @@
 ---
 name: "review-poster"
-description: "Post approved pull request review comments to GitHub using exact verified comment bodies and line metadata after explicit final confirmation."
+description: "Post an approved pull request review to GitHub using exact verified comment bodies and line metadata when comments are present."
 ---
 
 # Review Poster
 
 You are a PR review posting subagent. Perform the optional GitHub side effect
 after the orchestrator has shown the exact preview and received final user
-approval. Preserve verified comment bodies and metadata exactly.
+approval. Preserve verified comment bodies and metadata exactly when comments
+are present.
 
 ## Inputs
 
@@ -15,8 +16,8 @@ approval. Preserve verified comment bodies and metadata exactly.
 | ----- | -------- | ------- |
 | `PR_URL` | Yes | `https://github.com/org/repo/pull/1020` |
 | `OUTPUT_FILE` | Yes | `pr-1020-review.md` |
-| `VERIFIED_COMMENTS` | Yes | Comment package from `review-verifier` |
-| `REVIEW_DECISION` | Yes | `comment` or `request changes` |
+| `VERIFIED_COMMENTS` | No | Comment package from `review-verifier`, or empty for summary-only/no-finding reviews |
+| `REVIEW_DECISION` | Yes | `comment`, `request changes`, or `approve` |
 | `PREVIEW_APPROVED` | Yes | `true` |
 
 Posting is available only when `PREVIEW_APPROVED=true`.
@@ -24,13 +25,17 @@ Posting is available only when `PREVIEW_APPROVED=true`.
 ## Instructions
 
 1. Choose the posting method: REST `pulls/reviews` for batched line comments
-   plus a review event, or `gh pr review` for summary-only reviews.
+   plus a review event, or `gh pr review` or the GitHub review API for
+   summary-only reviews such as no-finding approvals.
 2. Load `../references/external-review-resources.md`, fetch the exact GitHub
    docs for the chosen method, and apply the documented fields.
-3. Validate every line comment has `path`, `line`, `side`, and any required
-   `start_line` or `start_side` before posting. Return the metadata-invalid
-   status when fields are incomplete.
-4. Post comments with the exact bodies and metadata from `VERIFIED_COMMENTS`.
+3. When `VERIFIED_COMMENTS` contains line comments, validate every line comment
+   has `path`, `line`, `side`, and any required `start_line` or `start_side`
+   before posting. Return the metadata-invalid status when fields are
+   incomplete.
+4. Post comments with the exact bodies and metadata from `VERIFIED_COMMENTS`, or
+   post the approved summary review with zero comments for summary-only/no-
+   finding reviews.
 5. Read back the created review or comments through the API or CLI and confirm
    they are visible.
 6. Before returning, load `../references/status-review-poster.md` and use that
@@ -38,7 +43,7 @@ Posting is available only when `PREVIEW_APPROVED=true`.
 
 ## Scope
 
-Your job is to post exact, already-verified comments after final approval,
+Your job is to post exact, already-verified review content after final approval,
 verify the side effect with read-back, and report failures without changing
 content. Leave review analysis, drafting, verification, and file writing to
 earlier phases.

--- a/skills/review-pull-request/subagents/review-poster.md
+++ b/skills/review-pull-request/subagents/review-poster.md
@@ -16,11 +16,17 @@ are present.
 | ----- | -------- | ------- |
 | `PR_URL` | Yes | `https://github.com/org/repo/pull/1020` |
 | `OUTPUT_FILE` | Yes | `pr-1020-review.md` |
-| `VERIFIED_COMMENTS` | No | Comment package from `review-verifier`, or empty for summary-only/no-finding reviews |
+| `VERIFIED_COMMENTS` | No | Verified comment package from `review-verifier`; omit or leave blank for summary-only/no-finding reviews |
 | `REVIEW_DECISION` | Yes | `comment`, `request changes`, or `approve` |
 | `PREVIEW_APPROVED` | Yes | `true` |
 
 Posting is available only when `PREVIEW_APPROVED=true`.
+
+Interpret `VERIFIED_COMMENTS` this way: absent or blank means there are zero
+verified line comments and the review body comes from `OUTPUT_FILE`; when it is
+present, parse line comments only from a `Comments:` list. An empty `Comments:`
+list also means zero line comments and uses `OUTPUT_FILE` as the complete review
+body.
 
 ## Instructions
 

--- a/skills/review-pull-request/subagents/review-poster.md
+++ b/skills/review-pull-request/subagents/review-poster.md
@@ -31,11 +31,13 @@ Posting is available only when `PREVIEW_APPROVED=true`.
    docs for the chosen method, and apply the documented fields.
 3. When `VERIFIED_COMMENTS` contains line comments, validate every line comment
    has `path`, `line`, `side`, and any required `start_line` or `start_side`
-   before posting. Return the metadata-invalid status when fields are
+   before posting. Return `POST: METADATA_INVALID` when fields are
    incomplete.
-4. Post comments with the exact bodies and metadata from `VERIFIED_COMMENTS`.
-   For summary-only/no-finding reviews, read `OUTPUT_FILE` and post the
-   approved review body from that file with zero comments.
+4. When `VERIFIED_COMMENTS` contains line comments, post them with the exact
+   bodies and metadata from `VERIFIED_COMMENTS`. For summary-only/no-finding
+   reviews, read `OUTPUT_FILE` and post the complete file contents verbatim as
+   the approved review body with zero comments, whether using `gh pr review` or
+   the GitHub review API.
 5. Read back the created review or comments through the API or CLI and confirm
    they are visible.
 6. Before returning, load `../references/status-review-poster.md` and use that


### PR DESCRIPTION
## Summary

This updates the review-pull-request skill so the review-poster subagent can post summary-only and no-finding reviews (including approvals) without requiring line comments. It also adds a Mermaid flow diagram documenting the full orchestrator workflow and readiness rules.

## Key Changes

- Make `VERIFIED_COMMENTS` optional and add `approve` as a valid `REVIEW_DECISION` in review-poster
- Document summary-only posting paths via `gh pr review` or the GitHub review API
- Add `flow-diagram.md` with the full PR review workflow, node styling, and a verifier/writer readiness gate
- Align SKILL.md registry wording with review-poster's expanded scope

## Impact

- Reviewers can post approval-only or no-finding reviews without blocked metadata validation
- No runtime migration required; skill definition changes only
- No automated tests in this repo for skill authoring

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to skill documentation and subagent instruction contracts, with no production code or data/auth logic modifications.
> 
> **Overview**
> Enables `review-poster` to post **summary-only/no-finding reviews** by making `VERIFIED_COMMENTS` optional, allowing `REVIEW_DECISION=approve`, and only performing line-metadata validation when line comments exist; for commentless reviews it posts the approved body from `OUTPUT_FILE` with zero comments.
> 
> Adds `flow-diagram.md` (Mermaid) to document the orchestrator’s phase flow, readiness gate (`VERIFY: PASS` + `WRITE: PASS`), and explicit posting approval requirements, and aligns the `SKILL.md` subagent registry wording with the poster’s expanded scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 919604b191dab0394d1f4b9f430f212d395310d0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->