### PR TITLE
docs(responding-to-pr-review-comments): add orchestrator flow diagram

### DIFF
--- a/skills/responding-to-pr-review-comments/flow-diagram.md
+++ b/skills/responding-to-pr-review-comments/flow-diagram.md
@@ -28,7 +28,9 @@ flowchart TD
   CLASSIFY --> USER_DECISION{Product intent or team preference decides the answer?}
   USER_DECISION -->|yes| ASK_DECISION[Ask one focused user question; record decision as evidence]
   ASK_DECISION --> REASSESS[Reassess only affected items with the user decision]
-  REASSESS --> USER_DECISION
+  REASSESS --> DECISION_RESOLVED{Decision resolved within allowed reassessment attempts?}
+  DECISION_RESOLVED -->|no| FAIL_VERIFY([PR_COMMENT_RESPONSE NEEDS_USER_DECISION])
+  DECISION_RESOLVED -->|yes| USER_DECISION
   USER_DECISION -->|no| DRAFT[Draft natural replies, per-comment action intents, and phase status blocks]
   DRAFT --> VERIFY[Verify evidence, tone, action intent, scope, unsupported targets, and posting safety]
   VERIFY --> VERIFY_OK{Verification passes?}
@@ -60,7 +62,7 @@ flowchart TD
   classDef success fill:#e8f5e9,stroke:#2e7d32,color:#000;
   classDef stop fill:#fdecea,stroke:#b02a37,color:#000;
 
-  class PRURL,DATA_OK,COMMENTS,EXT_NEEDED,USER_DECISION,VERIFY_OK,VERIFY_REPAIR,REPORT_PATH,POST_MODE,APPROVAL,TARGETS,POST_OK decision;
+  class PRURL,DATA_OK,COMMENTS,EXT_NEEDED,USER_DECISION,DECISION_RESOLVED,VERIFY_OK,VERIFY_REPAIR,REPORT_PATH,POST_MODE,APPROVAL,TARGETS,POST_OK decision;
   class INTAKE,FETCH,DISPATCH,CONTEXT,CLASSIFY,REASSESS,DRAFT,VERIFY,REPAIR check;
   class EXT_SOURCE guard;
   class ASK_PR,ASK_DECISION,ASK_OUTPUT,PREVIEW human;

--- a/skills/responding-to-pr-review-comments/flow-diagram.md
+++ b/skills/responding-to-pr-review-comments/flow-diagram.md
@@ -26,11 +26,11 @@ flowchart TD
   EXT_NEEDED -->|no| CLASSIFY
   EXT_SOURCE --> CLASSIFY[Classify each comment with evidence, risk, action intent, support level, and draft response path]
   CLASSIFY --> USER_DECISION{Product intent or team preference decides the answer?}
-  USER_DECISION -->|yes| ASK_DECISION[Ask one focused user question; record decision as evidence]
+  USER_DECISION -->|yes| DECISION_RETRY{Fewer than three user-decision cycles used?}
+  DECISION_RETRY -->|no| FAIL_DECISION([PR_COMMENT_RESPONSE NEEDS_USER_DECISION])
+  DECISION_RETRY -->|yes| ASK_DECISION[Ask one focused user question; record decision as evidence]
   ASK_DECISION --> REASSESS[Reassess only affected items with the user decision]
-  REASSESS --> DECISION_RESOLVED{Decision resolved within allowed reassessment attempts?}
-  DECISION_RESOLVED -->|no| FAIL_VERIFY([PR_COMMENT_RESPONSE NEEDS_USER_DECISION])
-  DECISION_RESOLVED -->|yes| USER_DECISION
+  REASSESS --> USER_DECISION
   USER_DECISION -->|no| DRAFT[Draft natural replies, per-comment action intents, and phase status blocks]
   DRAFT --> VERIFY[Verify evidence, tone, action intent, scope, unsupported targets, and posting safety]
   VERIFY --> VERIFY_OK{Verification passes?}
@@ -63,14 +63,14 @@ flowchart TD
   classDef cancelled fill:#fff3cd,stroke:#856404,color:#000;
   classDef stop fill:#fdecea,stroke:#b02a37,color:#000;
 
-  class PRURL,DATA_OK,COMMENTS,EXT_NEEDED,USER_DECISION,DECISION_RESOLVED,VERIFY_OK,VERIFY_REPAIR,REPORT_PATH,WRITE_OK,POST_MODE,APPROVAL,POST_OK decision;
+  class PRURL,DATA_OK,COMMENTS,EXT_NEEDED,USER_DECISION,DECISION_RETRY,VERIFY_OK,VERIFY_REPAIR,REPORT_PATH,WRITE_OK,POST_MODE,APPROVAL,POST_OK decision;
   class INTAKE,FETCH,DISPATCH,CONTEXT,CLASSIFY,REASSESS,DRAFT,VERIFY,REPAIR check;
   class EXT_SOURCE guard;
   class ASK_PR,ASK_DECISION,ASK_OUTPUT,PREVIEW human;
   class WRITE_REPORT,POST output;
   class NOT_POSTED,POSTED success;
   class CANCELLED cancelled;
-  class FAIL_DATA,FAIL_NONE,FAIL_VERIFY,FAIL_WRITE,FAIL_POST stop;
+  class FAIL_DATA,FAIL_NONE,FAIL_DECISION,FAIL_VERIFY,FAIL_WRITE,FAIL_POST stop;
 ```
 
 Report shape: the written report follows

--- a/skills/responding-to-pr-review-comments/flow-diagram.md
+++ b/skills/responding-to-pr-review-comments/flow-diagram.md
@@ -88,7 +88,8 @@ Report shape: the written report follows
 blocks and terminal response envelopes follow
 [`references/status-contracts.md`](./references/status-contracts.md).
 
-Readiness rule: the run is complete when it can emit `PR_COMMENT_RESPONSE:
-PASS` with a verified report path and posting status, or when it emits one of
-the documented failure envelope codes with the reason and next action. Posting
-is allowed only after the user approves the exact final preview.
+Readiness rule: the run is complete when it can emit `PR_COMMENT_RESPONSE: PASS`
+with a verified report path and `Posting: <not-posted | posted | cancelled>`,
+or when it emits one of the documented failure envelope codes with the reason
+and next action. Posting is allowed only after the user approves the exact final
+preview.

--- a/skills/responding-to-pr-review-comments/flow-diagram.md
+++ b/skills/responding-to-pr-review-comments/flow-diagram.md
@@ -16,9 +16,9 @@ flowchart TD
   ASK_PR --> PRURL
   PRURL -->|yes| FETCH[Collect GitHub review comments, summaries, PR comments, reply metadata, and PR diff]
   FETCH --> DATA_OK{GitHub data available?}
-  DATA_OK -->|auth, not found, or runtime error| FAIL_DATA([PR_COMMENT_RESPONSE AUTH, NOT_FOUND, or RESPONSE_ERROR])
+  DATA_OK -->|auth, not found, or runtime error| FAIL_DATA(["PR_COMMENT_RESPONSE: AUTH | NOT_FOUND | RESPONSE_ERROR"])
   DATA_OK -->|yes| COMMENTS{In-scope comments found?}
-  COMMENTS -->|no| FAIL_NONE([PR_COMMENT_RESPONSE NO_COMMENTS])
+  COMMENTS -->|no| FAIL_NONE(["PR_COMMENT_RESPONSE: NO_COMMENTS"])
   COMMENTS -->|yes| DISPATCH[Dispatch focused subagents; keep raw payloads, diffs, long docs, and command output outside compact orchestrator state]
   DISPATCH --> CONTEXT[Inspect relevant code, PR context, existing replies, and status contracts]
   CONTEXT --> EXT_NEEDED{Need current external source for a source-backed claim?}
@@ -27,7 +27,7 @@ flowchart TD
   EXT_SOURCE --> CLASSIFY[Classify each comment with evidence, risk, action intent, support level, and draft response path]
   CLASSIFY --> USER_DECISION{Product intent or team preference decides the answer?}
   USER_DECISION -->|yes| DECISION_RETRY{Fewer than three user-decision cycles used?}
-  DECISION_RETRY -->|no| FAIL_DECISION([PR_COMMENT_RESPONSE NEEDS_USER_DECISION])
+  DECISION_RETRY -->|no| FAIL_DECISION(["PR_COMMENT_RESPONSE: NEEDS_USER_DECISION"])
   DECISION_RETRY -->|yes| ASK_DECISION[Ask one focused user question; record decision as evidence]
   ASK_DECISION --> REASSESS[Reassess only affected items with the user decision]
   REASSESS --> USER_DECISION
@@ -37,22 +37,22 @@ flowchart TD
   VERIFY_OK -->|no, with fix target| VERIFY_REPAIR{Fewer than two targeted verification fix cycles used?}
   VERIFY_REPAIR -->|yes| REPAIR[Repair only the named collector, assessor, or drafter target]
   REPAIR --> VERIFY
-  VERIFY_REPAIR -->|no| FAIL_VERIFY([PR_COMMENT_RESPONSE VERIFY_FAIL])
+  VERIFY_REPAIR -->|no| FAIL_VERIFY(["PR_COMMENT_RESPONSE: VERIFY_FAIL"])
   VERIFY_OK -->|yes| REPORT_PATH{OUTPUT_FILE known and safe to write?}
   REPORT_PATH -->|no| ASK_OUTPUT[Ask for safe OUTPUT_FILE or confirm default report path]
   ASK_OUTPUT --> REPORT_PATH
   REPORT_PATH -->|yes| WRITE_REPORT[Write verified Markdown report to OUTPUT_FILE with drafts, evidence, risks, blockers, and action intents]
   WRITE_REPORT --> WRITE_OK{Report write succeeded?}
-  WRITE_OK -->|no| FAIL_WRITE([PR_COMMENT_RESPONSE WRITE_ERROR])
+  WRITE_OK -->|no| FAIL_WRITE(["PR_COMMENT_RESPONSE: WRITE_ERROR"])
   WRITE_OK -->|yes| POST_MODE{POSTING_MODE value?}
-  POST_MODE -->|draft-only| NOT_POSTED([PR_COMMENT_RESPONSE PASS, posting not-posted])
+  POST_MODE -->|draft-only| NOT_POSTED(["PR_COMMENT_RESPONSE: PASS<br/>Posting: not-posted"])
   POST_MODE -->|post-after-confirmation| PREVIEW[Show exact final posting preview: target thread, reply text, reason, risk, reversibility, and safer draft-only alternative]
   PREVIEW --> APPROVAL{User explicitly approves exact preview?}
-  APPROVAL -->|declined| CANCELLED([PR_COMMENT_RESPONSE CANCELLED, report remains local])
+  APPROVAL -->|declined| CANCELLED(["PR_COMMENT_RESPONSE: CANCELLED<br/>Posting: cancelled"])
   APPROVAL -->|approved| POST[Post exact approved replies to supported review-comment threads; record skipped unsupported targets]
   POST --> POST_OK{Posting succeeded?}
-  POST_OK -->|yes| POSTED([PR_COMMENT_RESPONSE PASS, posting posted])
-  POST_OK -->|no| FAIL_POST([PR_COMMENT_RESPONSE POST_ERROR])
+  POST_OK -->|yes| POSTED(["PR_COMMENT_RESPONSE: PASS<br/>Posting: posted"])
+  POST_OK -->|no| FAIL_POST(["PR_COMMENT_RESPONSE: POST_ERROR"])
 
   classDef guard fill:#fff3cd,stroke:#856404,color:#000;
   classDef check fill:#e7f1ff,stroke:#0b5ed7,color:#000;

--- a/skills/responding-to-pr-review-comments/flow-diagram.md
+++ b/skills/responding-to-pr-review-comments/flow-diagram.md
@@ -37,7 +37,7 @@ flowchart TD
   VERIFY_OK -->|no, with fix target| VERIFY_REPAIR{Fewer than two targeted verification fix cycles used?}
   VERIFY_REPAIR -->|yes| REPAIR[Repair only the named collector, assessor, or drafter target]
   REPAIR --> VERIFY
-  VERIFY_REPAIR -->|no| FAIL_VERIFY([PR_COMMENT_RESPONSE VERIFY_FAIL or NEEDS_USER_DECISION])
+  VERIFY_REPAIR -->|no| FAIL_VERIFY([PR_COMMENT_RESPONSE VERIFY_FAIL])
   VERIFY_OK -->|yes| REPORT_PATH{OUTPUT_FILE known and safe to write?}
   REPORT_PATH -->|no| ASK_OUTPUT[Ask for safe OUTPUT_FILE or confirm default report path]
   ASK_OUTPUT --> REPORT_PATH

--- a/skills/responding-to-pr-review-comments/flow-diagram.md
+++ b/skills/responding-to-pr-review-comments/flow-diagram.md
@@ -42,7 +42,9 @@ flowchart TD
   REPORT_PATH -->|no| ASK_OUTPUT[Ask for safe OUTPUT_FILE or confirm default report path]
   ASK_OUTPUT --> REPORT_PATH
   REPORT_PATH -->|yes| WRITE_REPORT[Write verified Markdown report to OUTPUT_FILE with drafts, evidence, risks, blockers, and action intents]
-  WRITE_REPORT --> POST_MODE{POSTING_MODE value?}
+  WRITE_REPORT --> WRITE_OK{Report write succeeded?}
+  WRITE_OK -->|no| FAIL_WRITE([PR_COMMENT_RESPONSE WRITE_ERROR])
+  WRITE_OK -->|yes| POST_MODE{POSTING_MODE value?}
   POST_MODE -->|draft-only| NOT_POSTED([PR_COMMENT_RESPONSE PASS, posting not-posted])
   POST_MODE -->|post-after-confirmation| PREVIEW[Show exact final posting preview: target thread, reply text, reason, risk, reversibility, and safer draft-only alternative]
   PREVIEW --> APPROVAL{User explicitly approves exact preview?}
@@ -62,13 +64,13 @@ flowchart TD
   classDef success fill:#e8f5e9,stroke:#2e7d32,color:#000;
   classDef stop fill:#fdecea,stroke:#b02a37,color:#000;
 
-  class PRURL,DATA_OK,COMMENTS,EXT_NEEDED,USER_DECISION,DECISION_RESOLVED,VERIFY_OK,VERIFY_REPAIR,REPORT_PATH,POST_MODE,APPROVAL,TARGETS,POST_OK decision;
+  class PRURL,DATA_OK,COMMENTS,EXT_NEEDED,USER_DECISION,DECISION_RESOLVED,VERIFY_OK,VERIFY_REPAIR,REPORT_PATH,WRITE_OK,POST_MODE,APPROVAL,TARGETS,POST_OK decision;
   class INTAKE,FETCH,DISPATCH,CONTEXT,CLASSIFY,REASSESS,DRAFT,VERIFY,REPAIR check;
   class EXT_SOURCE guard;
   class ASK_PR,ASK_DECISION,ASK_OUTPUT,PREVIEW human;
   class WRITE_REPORT,POST output;
   class NOT_POSTED,CANCELLED,POSTED success;
-  class FAIL_DATA,FAIL_NONE,FAIL_VERIFY,NEEDS_CHOICE,FAIL_POST stop;
+  class FAIL_DATA,FAIL_NONE,FAIL_VERIFY,FAIL_WRITE,NEEDS_CHOICE,FAIL_POST stop;
 ```
 
 Report shape: the written report follows

--- a/skills/responding-to-pr-review-comments/flow-diagram.md
+++ b/skills/responding-to-pr-review-comments/flow-diagram.md
@@ -69,26 +69,12 @@ flowchart TD
   class FAIL_DATA,FAIL_NONE,FAIL_VERIFY,NEEDS_CHOICE,FAIL_POST stop;
 ```
 
-Report contract:
+Report shape: the written report follows
+[`references/report-template.md`](./references/report-template.md). Status
+blocks and terminal response envelopes follow
+[`references/status-contracts.md`](./references/status-contracts.md).
 
-```text
-Status: not-posted | posted | cancelled | failed | blocked
-PR: <PR_URL>
-Output file: <OUTPUT_FILE>
-Scope and posting mode:
-Evidence checked:
-Per-comment assessment:
-Action intents:
-Draft replies:
-Unsupported targets:
-Risks and blockers:
-User decisions:
-Posting preview:
-Posting results:
-Failure envelope:
-```
-
-Readiness rule: the run is complete only when the report is verified and
-written, or when a blocked, cancelled, failed, or posted terminal state records
-the reason, evidence, and safe next action. Posting is allowed only after the
-user approves the exact final preview.
+Readiness rule: the run is complete when it can emit `PR_COMMENT_RESPONSE:
+PASS` with a verified report path and posting status, or when it emits one of
+the documented failure envelope codes with the reason and next action. Posting
+is allowed only after the user approves the exact final preview.

--- a/skills/responding-to-pr-review-comments/flow-diagram.md
+++ b/skills/responding-to-pr-review-comments/flow-diagram.md
@@ -16,9 +16,9 @@ flowchart TD
   ASK_PR --> PRURL
   PRURL -->|yes| FETCH[Collect GitHub review comments, summaries, PR comments, reply metadata, and PR diff]
   FETCH --> DATA_OK{GitHub data available?}
-  DATA_OK -->|auth or not found| FAIL_DATA([Blocked failure: auth, not-found, or runtime error])
+  DATA_OK -->|auth, not found, or runtime error| FAIL_DATA([PR_COMMENT_RESPONSE AUTH, NOT_FOUND, or RESPONSE_ERROR])
   DATA_OK -->|yes| COMMENTS{In-scope comments found?}
-  COMMENTS -->|no| FAIL_NONE([Blocked failure: no-comments])
+  COMMENTS -->|no| FAIL_NONE([PR_COMMENT_RESPONSE NO_COMMENTS])
   COMMENTS -->|yes| DISPATCH[Dispatch focused subagents; keep raw payloads, diffs, long docs, and command output outside compact orchestrator state]
   DISPATCH --> CONTEXT[Inspect relevant code, PR context, existing replies, and status contracts]
   CONTEXT --> EXT_NEEDED{Need current external source for a source-backed claim?}

--- a/skills/responding-to-pr-review-comments/flow-diagram.md
+++ b/skills/responding-to-pr-review-comments/flow-diagram.md
@@ -60,6 +60,7 @@ flowchart TD
   classDef human fill:#f3e8ff,stroke:#6f42c1,color:#000;
   classDef output fill:#e8f5e9,stroke:#2e7d32,color:#000;
   classDef success fill:#e8f5e9,stroke:#2e7d32,color:#000;
+  classDef cancelled fill:#fff3cd,stroke:#856404,color:#000;
   classDef stop fill:#fdecea,stroke:#b02a37,color:#000;
 
   class PRURL,DATA_OK,COMMENTS,EXT_NEEDED,USER_DECISION,DECISION_RESOLVED,VERIFY_OK,VERIFY_REPAIR,REPORT_PATH,WRITE_OK,POST_MODE,APPROVAL,POST_OK decision;
@@ -67,7 +68,8 @@ flowchart TD
   class EXT_SOURCE guard;
   class ASK_PR,ASK_DECISION,ASK_OUTPUT,PREVIEW human;
   class WRITE_REPORT,POST output;
-  class NOT_POSTED,CANCELLED,POSTED success;
+  class NOT_POSTED,POSTED success;
+  class CANCELLED cancelled;
   class FAIL_DATA,FAIL_NONE,FAIL_VERIFY,FAIL_WRITE,FAIL_POST stop;
 ```
 

--- a/skills/responding-to-pr-review-comments/flow-diagram.md
+++ b/skills/responding-to-pr-review-comments/flow-diagram.md
@@ -32,7 +32,10 @@ flowchart TD
   USER_DECISION -->|no| DRAFT[Draft natural replies, per-comment action intents, and phase status blocks]
   DRAFT --> VERIFY[Verify evidence, tone, action intent, scope, unsupported targets, and posting safety]
   VERIFY --> VERIFY_OK{Verification passes?}
-  VERIFY_OK -->|no| FAIL_VERIFY([Blocked failure: unrecoverable verification or needs-user-decision])
+  VERIFY_OK -->|no, with fix target| VERIFY_REPAIR{Fewer than two targeted verification fix cycles used?}
+  VERIFY_REPAIR -->|yes| REPAIR[Repair only the named collector, assessor, or drafter target]
+  REPAIR --> VERIFY
+  VERIFY_REPAIR -->|no| FAIL_VERIFY([PR_COMMENT_RESPONSE VERIFY_FAIL or NEEDS_USER_DECISION])
   VERIFY_OK -->|yes| REPORT_PATH{OUTPUT_FILE known and safe to write?}
   REPORT_PATH -->|no| ASK_OUTPUT[Ask for safe OUTPUT_FILE or confirm default report path]
   ASK_OUTPUT --> REPORT_PATH
@@ -57,8 +60,8 @@ flowchart TD
   classDef success fill:#e8f5e9,stroke:#2e7d32,color:#000;
   classDef stop fill:#fdecea,stroke:#b02a37,color:#000;
 
-  class PRURL,DATA_OK,COMMENTS,EXT_NEEDED,USER_DECISION,VERIFY_OK,REPORT_PATH,POST_MODE,APPROVAL,TARGETS,POST_OK decision;
-  class INTAKE,FETCH,DISPATCH,CONTEXT,CLASSIFY,REASSESS,DRAFT,VERIFY check;
+  class PRURL,DATA_OK,COMMENTS,EXT_NEEDED,USER_DECISION,VERIFY_OK,VERIFY_REPAIR,REPORT_PATH,POST_MODE,APPROVAL,TARGETS,POST_OK decision;
+  class INTAKE,FETCH,DISPATCH,CONTEXT,CLASSIFY,REASSESS,DRAFT,VERIFY,REPAIR check;
   class EXT_SOURCE guard;
   class ASK_PR,ASK_DECISION,ASK_OUTPUT,PREVIEW human;
   class WRITE_REPORT,POST output;

--- a/skills/responding-to-pr-review-comments/flow-diagram.md
+++ b/skills/responding-to-pr-review-comments/flow-diagram.md
@@ -1,0 +1,90 @@
+# Responding to PR Review Comments
+
+This workflow covers a PR review-response orchestrator that treats review
+comments as proposals to evaluate, not instructions to accept by default. The
+agent may collect GitHub and repository evidence, dispatch focused subagents,
+classify comments, draft replies, verify claims and tone, write a local Markdown
+report, and only post exact approved replies to supported GitHub review-comment
+threads. Mutations stay bounded: draft-only is the default, unsupported targets
+require user choice, and posting requires explicit approval of the final preview.
+
+```mermaid
+flowchart TD
+  START([Start: PR review-response run]) --> INTAKE[Normalize PR_URL, OUTPUT_FILE, POSTING_MODE, LANGUAGE_STYLE, COMMENT_SCOPE, and RESPONDER_LOGIN]
+  INTAKE --> PRURL{PR_URL present and unambiguous?}
+  PRURL -->|no| ASK_PR[Ask user for PR_URL]
+  ASK_PR --> PRURL
+  PRURL -->|yes| FETCH[Collect GitHub review comments, summaries, PR comments, reply metadata, and PR diff]
+  FETCH --> DATA_OK{GitHub data available?}
+  DATA_OK -->|auth or not found| FAIL_DATA([Blocked failure: auth, not-found, or runtime error])
+  DATA_OK -->|yes| COMMENTS{In-scope comments found?}
+  COMMENTS -->|no| FAIL_NONE([Blocked failure: no-comments])
+  COMMENTS -->|yes| DISPATCH[Dispatch focused subagents; keep raw payloads, diffs, long docs, and command output outside compact orchestrator state]
+  DISPATCH --> CONTEXT[Inspect relevant code, PR context, existing replies, and status contracts]
+  CONTEXT --> EXT_NEEDED{Need current external source for a source-backed claim?}
+  EXT_NEEDED -->|yes| EXT_SOURCE[Fetch only needed source; record claim, source, and reason]
+  EXT_NEEDED -->|no| CLASSIFY
+  EXT_SOURCE --> CLASSIFY[Classify each comment with evidence, risk, action intent, support level, and draft response path]
+  CLASSIFY --> USER_DECISION{Product intent or team preference decides the answer?}
+  USER_DECISION -->|yes| ASK_DECISION[Ask one focused user question; record decision as evidence]
+  ASK_DECISION --> DRAFT
+  USER_DECISION -->|no| DRAFT[Draft natural replies, per-comment action intents, and phase status blocks]
+  DRAFT --> VERIFY[Verify evidence, tone, action intent, scope, unsupported targets, and posting safety]
+  VERIFY --> VERIFY_OK{Verification passes?}
+  VERIFY_OK -->|no| FAIL_VERIFY([Blocked failure: unrecoverable verification or needs-user-decision])
+  VERIFY_OK -->|yes| REPORT_PATH{OUTPUT_FILE known and safe to write?}
+  REPORT_PATH -->|no| ASK_OUTPUT[Ask for safe OUTPUT_FILE or confirm default report path]
+  ASK_OUTPUT --> REPORT_PATH
+  REPORT_PATH -->|yes| WRITE_REPORT[Write verified Markdown report to OUTPUT_FILE with drafts, evidence, risks, blockers, and action intents]
+  WRITE_REPORT --> POST_MODE{POSTING_MODE requests posting?}
+  POST_MODE -->|no or draft-only| NOT_POSTED([Complete: not-posted with verified report path])
+  POST_MODE -->|yes| PREVIEW[Show exact final posting preview: target thread, reply text, reason, risk, reversibility, and safer draft-only alternative]
+  PREVIEW --> APPROVAL{User explicitly approves exact preview?}
+  APPROVAL -->|declined| CANCELLED([Complete: cancelled; report remains local])
+  APPROVAL -->|approved| TARGETS{All targets are supported review-comment threads?}
+  TARGETS -->|no| NEEDS_CHOICE([Blocked: requires-user-choice for unsupported posting targets])
+  TARGETS -->|yes| POST[Post exact approved replies; record GitHub result metadata]
+  POST --> POST_OK{Posting succeeded?}
+  POST_OK -->|yes| POSTED([Complete: posted with posting result])
+  POST_OK -->|no| FAIL_POST([Failed: posting error with report and failure envelope])
+
+  classDef guard fill:#fff3cd,stroke:#856404,color:#000;
+  classDef check fill:#e7f1ff,stroke:#0b5ed7,color:#000;
+  classDef decision fill:#f8f9fa,stroke:#495057,color:#000;
+  classDef human fill:#f3e8ff,stroke:#6f42c1,color:#000;
+  classDef output fill:#e8f5e9,stroke:#2e7d32,color:#000;
+  classDef success fill:#e8f5e9,stroke:#2e7d32,color:#000;
+  classDef stop fill:#fdecea,stroke:#b02a37,color:#000;
+
+  class PRURL,DATA_OK,COMMENTS,EXT_NEEDED,USER_DECISION,VERIFY_OK,REPORT_PATH,POST_MODE,APPROVAL,TARGETS,POST_OK decision;
+  class INTAKE,FETCH,DISPATCH,CONTEXT,CLASSIFY,DRAFT,VERIFY check;
+  class EXT_SOURCE guard;
+  class ASK_PR,ASK_DECISION,ASK_OUTPUT,PREVIEW human;
+  class WRITE_REPORT,POST output;
+  class NOT_POSTED,CANCELLED,POSTED success;
+  class FAIL_DATA,FAIL_NONE,FAIL_VERIFY,NEEDS_CHOICE,FAIL_POST stop;
+```
+
+Report contract:
+
+```text
+Status: not-posted | posted | cancelled | failed | blocked
+PR: <PR_URL>
+Output file: <OUTPUT_FILE>
+Scope and posting mode:
+Evidence checked:
+Per-comment assessment:
+Action intents:
+Draft replies:
+Unsupported targets:
+Risks and blockers:
+User decisions:
+Posting preview:
+Posting results:
+Failure envelope:
+```
+
+Readiness rule: the run is complete only when the report is verified and
+written, or when a blocked, cancelled, failed, or posted terminal state records
+the reason, evidence, and safe next action. Posting is allowed only after the
+user approves the exact final preview.

--- a/skills/responding-to-pr-review-comments/flow-diagram.md
+++ b/skills/responding-to-pr-review-comments/flow-diagram.md
@@ -37,7 +37,12 @@ flowchart TD
   ASK_DECISION --> REASSESS[Reassess only affected items with the user decision]
   REASSESS --> USER_DECISION
   USER_DECISION -->|no| DRAFT[Draft natural replies, per-comment action intents, and phase status blocks]
-  DRAFT --> VERIFY[Verify evidence, tone, action intent, scope, unsupported targets, and posting safety]
+  DRAFT --> DRAFT_DECISION{DRAFT: NEEDS_USER_DECISION?}
+  DRAFT_DECISION -->|yes| DRAFT_RETRY{Fewer than three draft-decision cycles used?}
+  DRAFT_RETRY -->|no| FAIL_DECISION
+  DRAFT_RETRY -->|yes| ASK_DRAFT[Ask one focused wording or response-choice question]
+  ASK_DRAFT --> DRAFT
+  DRAFT_DECISION -->|no| VERIFY[Verify evidence, tone, action intent, scope, unsupported targets, and posting safety]
   VERIFY --> VERIFY_OK{Verification passes?}
   VERIFY_OK -->|no, with fix target| VERIFY_REPAIR{Fewer than two targeted verification fix cycles used?}
   VERIFY_REPAIR -->|yes| REPAIR[Repair only the named collector, assessor, or drafter target]
@@ -68,10 +73,10 @@ flowchart TD
   classDef cancelled fill:#fff3cd,stroke:#856404,color:#000;
   classDef stop fill:#fdecea,stroke:#b02a37,color:#000;
 
-  class PRURL,DATA_OK,COMMENTS,EXT_NEEDED,ASSESS_CONTEXT,CONTEXT_RETRY,USER_DECISION,DECISION_RETRY,VERIFY_OK,VERIFY_REPAIR,REPORT_PATH,WRITE_OK,POST_MODE,APPROVAL,POST_OK decision;
+  class PRURL,DATA_OK,COMMENTS,EXT_NEEDED,ASSESS_CONTEXT,CONTEXT_RETRY,USER_DECISION,DECISION_RETRY,DRAFT_DECISION,DRAFT_RETRY,VERIFY_OK,VERIFY_REPAIR,REPORT_PATH,WRITE_OK,POST_MODE,APPROVAL,POST_OK decision;
   class INTAKE,FETCH,DISPATCH,CONTEXT,CLASSIFY,NARROW_LOOKUP,REASSESS,DRAFT,VERIFY,REPAIR check;
   class EXT_SOURCE guard;
-  class ASK_PR,ASK_DECISION,ASK_OUTPUT,PREVIEW human;
+  class ASK_PR,ASK_DECISION,ASK_DRAFT,ASK_OUTPUT,PREVIEW human;
   class WRITE_REPORT,POST output;
   class NOT_POSTED,POSTED success;
   class CANCELLED cancelled;

--- a/skills/responding-to-pr-review-comments/flow-diagram.md
+++ b/skills/responding-to-pr-review-comments/flow-diagram.md
@@ -40,17 +40,17 @@ flowchart TD
   REPORT_PATH -->|no| ASK_OUTPUT[Ask for safe OUTPUT_FILE or confirm default report path]
   ASK_OUTPUT --> REPORT_PATH
   REPORT_PATH -->|yes| WRITE_REPORT[Write verified Markdown report to OUTPUT_FILE with drafts, evidence, risks, blockers, and action intents]
-  WRITE_REPORT --> POST_MODE{POSTING_MODE requests posting?}
-  POST_MODE -->|no or draft-only| NOT_POSTED([Complete: not-posted with verified report path])
-  POST_MODE -->|yes| PREVIEW[Show exact final posting preview: target thread, reply text, reason, risk, reversibility, and safer draft-only alternative]
+  WRITE_REPORT --> POST_MODE{POSTING_MODE value?}
+  POST_MODE -->|draft-only| NOT_POSTED([PR_COMMENT_RESPONSE PASS, posting not-posted])
+  POST_MODE -->|post-after-confirmation| PREVIEW[Show exact final posting preview: target thread, reply text, reason, risk, reversibility, and safer draft-only alternative]
   PREVIEW --> APPROVAL{User explicitly approves exact preview?}
-  APPROVAL -->|declined| CANCELLED([Complete: cancelled; report remains local])
+  APPROVAL -->|declined| CANCELLED([PR_COMMENT_RESPONSE CANCELLED, report remains local])
   APPROVAL -->|approved| TARGETS{All targets are supported review-comment threads?}
-  TARGETS -->|no| NEEDS_CHOICE([Blocked: requires-user-choice for unsupported posting targets])
+  TARGETS -->|no| NEEDS_CHOICE([PR_COMMENT_RESPONSE NEEDS_USER_DECISION, unsupported targets require user choice])
   TARGETS -->|yes| POST[Post exact approved replies; record GitHub result metadata]
   POST --> POST_OK{Posting succeeded?}
-  POST_OK -->|yes| POSTED([Complete: posted with posting result])
-  POST_OK -->|no| FAIL_POST([Failed: posting error with report and failure envelope])
+  POST_OK -->|yes| POSTED([PR_COMMENT_RESPONSE PASS, posting posted])
+  POST_OK -->|no| FAIL_POST([PR_COMMENT_RESPONSE POST_ERROR])
 
   classDef guard fill:#fff3cd,stroke:#856404,color:#000;
   classDef check fill:#e7f1ff,stroke:#0b5ed7,color:#000;

--- a/skills/responding-to-pr-review-comments/flow-diagram.md
+++ b/skills/responding-to-pr-review-comments/flow-diagram.md
@@ -49,9 +49,7 @@ flowchart TD
   POST_MODE -->|post-after-confirmation| PREVIEW[Show exact final posting preview: target thread, reply text, reason, risk, reversibility, and safer draft-only alternative]
   PREVIEW --> APPROVAL{User explicitly approves exact preview?}
   APPROVAL -->|declined| CANCELLED([PR_COMMENT_RESPONSE CANCELLED, report remains local])
-  APPROVAL -->|approved| TARGETS{All targets are supported review-comment threads?}
-  TARGETS -->|no| NEEDS_CHOICE([PR_COMMENT_RESPONSE NEEDS_USER_DECISION, unsupported targets require user choice])
-  TARGETS -->|yes| POST[Post exact approved replies; record GitHub result metadata]
+  APPROVAL -->|approved| POST[Post exact approved replies to supported review-comment threads; record skipped unsupported targets]
   POST --> POST_OK{Posting succeeded?}
   POST_OK -->|yes| POSTED([PR_COMMENT_RESPONSE PASS, posting posted])
   POST_OK -->|no| FAIL_POST([PR_COMMENT_RESPONSE POST_ERROR])
@@ -64,13 +62,13 @@ flowchart TD
   classDef success fill:#e8f5e9,stroke:#2e7d32,color:#000;
   classDef stop fill:#fdecea,stroke:#b02a37,color:#000;
 
-  class PRURL,DATA_OK,COMMENTS,EXT_NEEDED,USER_DECISION,DECISION_RESOLVED,VERIFY_OK,VERIFY_REPAIR,REPORT_PATH,WRITE_OK,POST_MODE,APPROVAL,TARGETS,POST_OK decision;
+  class PRURL,DATA_OK,COMMENTS,EXT_NEEDED,USER_DECISION,DECISION_RESOLVED,VERIFY_OK,VERIFY_REPAIR,REPORT_PATH,WRITE_OK,POST_MODE,APPROVAL,POST_OK decision;
   class INTAKE,FETCH,DISPATCH,CONTEXT,CLASSIFY,REASSESS,DRAFT,VERIFY,REPAIR check;
   class EXT_SOURCE guard;
   class ASK_PR,ASK_DECISION,ASK_OUTPUT,PREVIEW human;
   class WRITE_REPORT,POST output;
   class NOT_POSTED,CANCELLED,POSTED success;
-  class FAIL_DATA,FAIL_NONE,FAIL_VERIFY,FAIL_WRITE,NEEDS_CHOICE,FAIL_POST stop;
+  class FAIL_DATA,FAIL_NONE,FAIL_VERIFY,FAIL_WRITE,FAIL_POST stop;
 ```
 
 Report shape: the written report follows

--- a/skills/responding-to-pr-review-comments/flow-diagram.md
+++ b/skills/responding-to-pr-review-comments/flow-diagram.md
@@ -25,7 +25,12 @@ flowchart TD
   EXT_NEEDED -->|yes| EXT_SOURCE[Fetch only needed source; record claim, source, and reason]
   EXT_NEEDED -->|no| CLASSIFY
   EXT_SOURCE --> CLASSIFY[Classify each comment with evidence, risk, action intent, support level, and draft response path]
-  CLASSIFY --> USER_DECISION{Product intent or team preference decides the answer?}
+  CLASSIFY --> ASSESS_CONTEXT{ASSESS: NEEDS_CONTEXT?}
+  ASSESS_CONTEXT -->|yes| CONTEXT_RETRY{Narrow context redispatch already used?}
+  CONTEXT_RETRY -->|no| NARROW_LOOKUP[Run the requested narrow lookup once and keep only compact evidence]
+  NARROW_LOOKUP --> CLASSIFY
+  CONTEXT_RETRY -->|yes| FAIL_CONTEXT(["PR_COMMENT_RESPONSE: RESPONSE_ERROR"])
+  ASSESS_CONTEXT -->|no| USER_DECISION{Product intent or team preference decides the answer?}
   USER_DECISION -->|yes| DECISION_RETRY{Fewer than three user-decision cycles used?}
   DECISION_RETRY -->|no| FAIL_DECISION(["PR_COMMENT_RESPONSE: NEEDS_USER_DECISION"])
   DECISION_RETRY -->|yes| ASK_DECISION[Ask one focused user question; record decision as evidence]
@@ -63,14 +68,14 @@ flowchart TD
   classDef cancelled fill:#fff3cd,stroke:#856404,color:#000;
   classDef stop fill:#fdecea,stroke:#b02a37,color:#000;
 
-  class PRURL,DATA_OK,COMMENTS,EXT_NEEDED,USER_DECISION,DECISION_RETRY,VERIFY_OK,VERIFY_REPAIR,REPORT_PATH,WRITE_OK,POST_MODE,APPROVAL,POST_OK decision;
-  class INTAKE,FETCH,DISPATCH,CONTEXT,CLASSIFY,REASSESS,DRAFT,VERIFY,REPAIR check;
+  class PRURL,DATA_OK,COMMENTS,EXT_NEEDED,ASSESS_CONTEXT,CONTEXT_RETRY,USER_DECISION,DECISION_RETRY,VERIFY_OK,VERIFY_REPAIR,REPORT_PATH,WRITE_OK,POST_MODE,APPROVAL,POST_OK decision;
+  class INTAKE,FETCH,DISPATCH,CONTEXT,CLASSIFY,NARROW_LOOKUP,REASSESS,DRAFT,VERIFY,REPAIR check;
   class EXT_SOURCE guard;
   class ASK_PR,ASK_DECISION,ASK_OUTPUT,PREVIEW human;
   class WRITE_REPORT,POST output;
   class NOT_POSTED,POSTED success;
   class CANCELLED cancelled;
-  class FAIL_DATA,FAIL_NONE,FAIL_DECISION,FAIL_VERIFY,FAIL_WRITE,FAIL_POST stop;
+  class FAIL_DATA,FAIL_NONE,FAIL_CONTEXT,FAIL_DECISION,FAIL_VERIFY,FAIL_WRITE,FAIL_POST stop;
 ```
 
 Report shape: the written report follows

--- a/skills/responding-to-pr-review-comments/flow-diagram.md
+++ b/skills/responding-to-pr-review-comments/flow-diagram.md
@@ -27,7 +27,8 @@ flowchart TD
   EXT_SOURCE --> CLASSIFY[Classify each comment with evidence, risk, action intent, support level, and draft response path]
   CLASSIFY --> USER_DECISION{Product intent or team preference decides the answer?}
   USER_DECISION -->|yes| ASK_DECISION[Ask one focused user question; record decision as evidence]
-  ASK_DECISION --> DRAFT
+  ASK_DECISION --> REASSESS[Reassess only affected items with the user decision]
+  REASSESS --> USER_DECISION
   USER_DECISION -->|no| DRAFT[Draft natural replies, per-comment action intents, and phase status blocks]
   DRAFT --> VERIFY[Verify evidence, tone, action intent, scope, unsupported targets, and posting safety]
   VERIFY --> VERIFY_OK{Verification passes?}
@@ -57,7 +58,7 @@ flowchart TD
   classDef stop fill:#fdecea,stroke:#b02a37,color:#000;
 
   class PRURL,DATA_OK,COMMENTS,EXT_NEEDED,USER_DECISION,VERIFY_OK,REPORT_PATH,POST_MODE,APPROVAL,TARGETS,POST_OK decision;
-  class INTAKE,FETCH,DISPATCH,CONTEXT,CLASSIFY,DRAFT,VERIFY check;
+  class INTAKE,FETCH,DISPATCH,CONTEXT,CLASSIFY,REASSESS,DRAFT,VERIFY check;
   class EXT_SOURCE guard;
   class ASK_PR,ASK_DECISION,ASK_OUTPUT,PREVIEW human;
   class WRITE_REPORT,POST output;


### PR DESCRIPTION
## Summary

Adds a Mermaid flow diagram for the responding-to-pr-review-comments skill orchestrator. The diagram documents intake, subagent dispatch, verification gates, local report writing, and the posting approval path so the workflow is easier to follow without reading every subagent contract.

## Key Changes

- Adds `flow-diagram.md` with a full orchestrator flowchart covering comment intake, classification, drafting, verification, report output, and optional GitHub posting.
- Documents the report contract block and readiness rule for terminal states (not-posted, posted, cancelled, failed, blocked).

## Impact

- Documentation-only; no runtime or skill behavior changes.
- Aligns with the same flow-diagram pattern used by other skills in this repo.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds a new Markdown diagram and references existing report/status contracts, with no runtime behavior impact.
> 
> **Overview**
> Adds `skills/responding-to-pr-review-comments/flow-diagram.md`, a Mermaid flowchart documenting the end-to-end orchestration for collecting PR review comments, classifying/drafting responses, running verification/repair gates, writing the local Markdown report, and optionally posting replies only after explicit user approval.
> 
> The diagram also links the workflow to the existing `references/report-template.md` and `references/status-contracts.md`, and states a readiness rule for emitting final `PR_COMMENT_RESPONSE` terminal outcomes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9aa23b0453006609351a29295a42413ff6c6c9a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->