### PR TITLE
docs(committing-scoped-changes): add orchestrator flow diagram

### DIFF
--- a/skills/committing-scoped-changes/flow-diagram.md
+++ b/skills/committing-scoped-changes/flow-diagram.md
@@ -68,3 +68,16 @@ flowchart TD
   class DONE success;
   class WAIT_PATHS,STOP_NO_AUTH,NO_CHANGES,WAIT_CONTEXT,STATE_BLOCKED,WAIT_DECISION,PLAN_BLOCKED,SCOPE_DECLINED,VERIFY_BLOCKED,EXEC_BLOCKED stop;
 ```
+
+Readiness rule: commit execution is allowed only when `COMMIT_REQUEST_CONFIRMED=true`, `CHANGE_PATHS` is explicit, the planner has approved scoped commit groups, and any required human scope decision has an approve branch.
+
+Final report contract:
+
+| Field | Required Content |
+| --- | --- |
+| Status | success, `NO_SCOPED_CHANGES`, blocked, error, or failure |
+| Commits | SHA and message for each created commit |
+| Verification | Checks run and pass/fail outcome |
+| Remaining scoped changes | Any in-scope changes not committed and why |
+| Untouched unrelated work | Confirmation that unrelated work was preserved |
+| Questions or blockers | Only unresolved decisions needed for safe continuation |

--- a/skills/committing-scoped-changes/flow-diagram.md
+++ b/skills/committing-scoped-changes/flow-diagram.md
@@ -81,3 +81,12 @@ Final report contract:
 | Remaining scoped changes | Any in-scope changes not committed and why |
 | Untouched unrelated work | Confirmation that unrelated work was preserved |
 | Questions or blockers | Only unresolved decisions needed for safe continuation |
+
+Facts:
+
+| Item | Detail |
+| --- | --- |
+| Authority | The orchestrator normalizes authority and delegates git inspection, staging, verification, and commit creation to specialists. |
+| Scope | User-provided `CHANGE_PATHS` is the commit allow-list. |
+| Existing staged changes | Treated as facts for planning, not as permission to commit. |
+| External sources | Optional and used only when they can change a commit decision. |

--- a/skills/committing-scoped-changes/flow-diagram.md
+++ b/skills/committing-scoped-changes/flow-diagram.md
@@ -52,4 +52,19 @@ flowchart TD
   MORE_GROUPS -->|yes| COMMIT_NEXT
   MORE_GROUPS -->|no| FINAL_REPORT[Load orchestrator report contract and synthesize final report]
   FINAL_REPORT --> DONE([Success: report SHAs, verification, remaining scoped changes, untouched unrelated work])
+
+  classDef guard fill:#fff3cd,stroke:#856404,color:#000;
+  classDef check fill:#e7f1ff,stroke:#0b5ed7,color:#000;
+  classDef decision fill:#f8f9fa,stroke:#495057,color:#000;
+  classDef human fill:#f3e8ff,stroke:#6f42c1,color:#000;
+  classDef output fill:#e8f5e9,stroke:#2e7d32,color:#000;
+  classDef success fill:#e8f5e9,stroke:#2e7d32,color:#000;
+  classDef stop fill:#fdecea,stroke:#b02a37,color:#000;
+
+  class HAS_PATHS,AUTH,STATE_RESULT,REF_NEED,PLAN_RESULT,SENSITIVE_SCOPE,EXEC_RESULT,RECOVER,REMAINING,MORE_GROUPS decision;
+  class INTAKE,SET_SCOPE,DISPATCH_STATE,LOOKUP_REF,PLAN,APPROVE_GROUPS,EXEC_ACTIONS,RECORD_SHA,REFRESH check;
+  class ASK_PATHS,ASK_CONTEXT,ASK_DECISION,HUMAN_SCOPE human;
+  class FINAL_REPORT output;
+  class DONE success;
+  class WAIT_PATHS,STOP_NO_AUTH,NO_CHANGES,WAIT_CONTEXT,STATE_BLOCKED,WAIT_DECISION,PLAN_BLOCKED,SCOPE_DECLINED,VERIFY_BLOCKED,EXEC_BLOCKED stop;
 ```

--- a/skills/committing-scoped-changes/flow-diagram.md
+++ b/skills/committing-scoped-changes/flow-diagram.md
@@ -70,16 +70,10 @@ flowchart TD
 
 Readiness rule: commit execution is allowed only when `COMMIT_REQUEST_CONFIRMED=true`, `CHANGE_PATHS` is explicit, the planner has approved scoped commit groups, and any required human scope decision has an approve branch.
 
-Final report contract:
-
-| Field | Required Content |
-| --- | --- |
-| Status | success, `NO_SCOPED_CHANGES`, blocked, error, or failure |
-| Commits | SHA and message for each created commit |
-| Verification | Checks run and pass/fail outcome |
-| Remaining scoped changes | Any in-scope changes not committed and why |
-| Untouched unrelated work | Confirmation that unrelated work was preserved |
-| Questions or blockers | Only unresolved decisions needed for safe continuation |
+Final report contract: load
+[`./references/report-contract-orchestrator.md`](./references/report-contract-orchestrator.md)
+after commit execution or terminal failure and use its success or failure
+structure as the source of truth.
 
 Facts:
 

--- a/skills/committing-scoped-changes/flow-diagram.md
+++ b/skills/committing-scoped-changes/flow-diagram.md
@@ -22,8 +22,8 @@ flowchart TD
   STATE_RESULT -->|PASS| REF_NEED{Reference need named?}
 
   REF_NEED -->|yes| LOOKUP_REF[Load external-sources and select only relevant public URL]
-  REF_NEED -->|no| PLAN[Dispatch commit-boundary-planner with state facts]
-  LOOKUP_REF --> PLAN[Dispatch commit-boundary-planner with selected URL conclusion]
+  REF_NEED -->|no| PLAN[Dispatch commit-boundary-planner]
+  LOOKUP_REF --> PLAN
 
   PLAN --> PLAN_RESULT{COMMIT_PLAN result}
   PLAN_RESULT -->|NEEDS_DECISION| ASK_DECISION[Ask smallest user decision question]

--- a/skills/committing-scoped-changes/flow-diagram.md
+++ b/skills/committing-scoped-changes/flow-diagram.md
@@ -97,3 +97,11 @@ Assumptions:
 | --- | --- |
 | Commit request | `COMMIT_REQUEST_CONFIRMED=true` is set only after the user asks for commits. |
 | Report synthesis | The orchestrator loads the final report contract after commit execution or terminal failure. |
+
+Risks:
+
+| Risk | Mitigation |
+| --- | --- |
+| Unrelated work could be staged or committed accidentally | Executor stages only approved scoped groups and reviews staged diff before commit. |
+| Hooks or generated files can change the worktree | Orchestrator refreshes scoped state after each commit and replans if needed. |
+| Scope ambiguity can cause unsafe commits | Workflow stops for one targeted user question. |

--- a/skills/committing-scoped-changes/flow-diagram.md
+++ b/skills/committing-scoped-changes/flow-diagram.md
@@ -1,3 +1,55 @@
 # Committing Scoped Changes
 
 This workflow commits only user-approved scoped changes. The orchestrator normalizes commit authority and path scope, dispatches specialists for state inspection, boundary planning, and commit execution, and asks one targeted user question when required. `CHANGE_PATHS` is the commit allow-list; existing staged changes are evidence to plan around, not permission to commit. The workflow must preserve unrelated work, refresh state after each commit, and never expand scope or leave meaningful in-scope changes uncommitted without user approval.
+
+```mermaid
+flowchart TD
+  START([Start: user invokes committing-scoped-changes]) --> INTAKE[Normalize inputs: CHANGE_PATHS, context, style, verification hint]
+  INTAKE --> HAS_PATHS{CHANGE_PATHS present and unambiguous?}
+  HAS_PATHS -->|no| ASK_PATHS[Ask one targeted question for allowed paths]
+  ASK_PATHS --> WAIT_PATHS([Needs input: path scope])
+  HAS_PATHS -->|yes| AUTH{User asked to create commits?}
+
+  AUTH -->|no| STOP_NO_AUTH([Blocked: no commit request authority])
+  AUTH -->|yes| SET_SCOPE[Set COMMIT_REQUEST_CONFIRMED=true and treat CHANGE_PATHS as allow-list]
+  SET_SCOPE --> DISPATCH_STATE[Dispatch scoped-state-summarizer for scoped git state and local context]
+  DISPATCH_STATE --> STATE_RESULT{SCOPED_STATE result}
+
+  STATE_RESULT -->|NO_SCOPED_CHANGES| NO_CHANGES([NO_SCOPED_CHANGES: report no commit-worthy scoped work])
+  STATE_RESULT -->|NEEDS_CONTEXT| ASK_CONTEXT[Ask one targeted context question]
+  ASK_CONTEXT --> WAIT_CONTEXT([Needs input: context])
+  STATE_RESULT -->|BLOCKED or ERROR| STATE_BLOCKED([Blocked: report state failure contract])
+  STATE_RESULT -->|PASS| REF_NEED{Reference need named?}
+
+  REF_NEED -->|yes| LOOKUP_REF[Load external-sources and select only relevant public URL]
+  REF_NEED -->|no| PLAN[Dispatch commit-boundary-planner with state facts]
+  LOOKUP_REF --> PLAN[Dispatch commit-boundary-planner with selected URL conclusion]
+
+  PLAN --> PLAN_RESULT{COMMIT_PLAN result}
+  PLAN_RESULT -->|NEEDS_DECISION| ASK_DECISION[Ask smallest user decision question]
+  ASK_DECISION --> WAIT_DECISION([Needs input: decision])
+  PLAN_RESULT -->|BLOCKED or ERROR| PLAN_BLOCKED([Blocked: report planning failure contract])
+  PLAN_RESULT -->|PASS| APPROVE_GROUPS[Use approved commit groups, messages, and verification checks]
+
+  APPROVE_GROUPS --> SENSITIVE_SCOPE{Plan expands scope or leaves meaningful in-scope changes uncommitted?}
+  SENSITIVE_SCOPE -->|yes| HUMAN_SCOPE[Human gate: explain target, reason, risk, safer alternative, approve or decline]
+  HUMAN_SCOPE -->|approved| COMMIT_NEXT[Dispatch scoped-commit-executor for next approved group]
+  HUMAN_SCOPE -->|declined| SCOPE_DECLINED([Blocked: scope decision declined])
+  SENSITIVE_SCOPE -->|no| COMMIT_NEXT[Dispatch scoped-commit-executor for next approved group]
+
+  COMMIT_NEXT --> EXEC_ACTIONS[Executor stages only group paths, reviews staged diff, runs verification, creates commit]
+  EXEC_ACTIONS --> EXEC_RESULT{COMMIT_EXECUTE result}
+  EXEC_RESULT -->|VERIFY_FAILED| RECOVER{Safe in-scope recovery available and attempts remain?}
+  RECOVER -->|yes| COMMIT_NEXT
+  RECOVER -->|no| VERIFY_BLOCKED([Blocked: verification failure contract])
+  EXEC_RESULT -->|COMMIT_ERROR or ERROR| EXEC_BLOCKED([Blocked: commit execution failure contract])
+  EXEC_RESULT -->|PASS| RECORD_SHA[Record commit SHA and verification evidence]
+
+  RECORD_SHA --> REFRESH[Refresh scoped state because hooks, generated files, or concurrent edits may change safety]
+  REFRESH --> REMAINING{Remaining scoped changes differ from approved plan?}
+  REMAINING -->|yes| PLAN
+  REMAINING -->|no| MORE_GROUPS{More approved groups?}
+  MORE_GROUPS -->|yes| COMMIT_NEXT
+  MORE_GROUPS -->|no| FINAL_REPORT[Load orchestrator report contract and synthesize final report]
+  FINAL_REPORT --> DONE([Success: report SHAs, verification, remaining scoped changes, untouched unrelated work])
+```

--- a/skills/committing-scoped-changes/flow-diagram.md
+++ b/skills/committing-scoped-changes/flow-diagram.md
@@ -47,7 +47,7 @@ flowchart TD
 
   RECORD_SHA --> REFRESH[Refresh scoped state because hooks, generated files, or concurrent edits may change safety]
   REFRESH --> REMAINING{Remaining scoped changes differ from approved plan?}
-  REMAINING -->|yes| PLAN
+  REMAINING -->|yes| REF_NEED
   REMAINING -->|no| MORE_GROUPS{More approved groups?}
   MORE_GROUPS -->|yes| COMMIT_NEXT
   MORE_GROUPS -->|no| FINAL_REPORT[Load orchestrator report contract and synthesize final report]

--- a/skills/committing-scoped-changes/flow-diagram.md
+++ b/skills/committing-scoped-changes/flow-diagram.md
@@ -1,0 +1,3 @@
+# Committing Scoped Changes
+
+This workflow commits only user-approved scoped changes. The orchestrator normalizes commit authority and path scope, dispatches specialists for state inspection, boundary planning, and commit execution, and asks one targeted user question when required. `CHANGE_PATHS` is the commit allow-list; existing staged changes are evidence to plan around, not permission to commit. The workflow must preserve unrelated work, refresh state after each commit, and never expand scope or leave meaningful in-scope changes uncommitted without user approval.

--- a/skills/committing-scoped-changes/flow-diagram.md
+++ b/skills/committing-scoped-changes/flow-diagram.md
@@ -90,3 +90,10 @@ Facts:
 | Scope | User-provided `CHANGE_PATHS` is the commit allow-list. |
 | Existing staged changes | Treated as facts for planning, not as permission to commit. |
 | External sources | Optional and used only when they can change a commit decision. |
+
+Assumptions:
+
+| Item | Detail |
+| --- | --- |
+| Commit request | `COMMIT_REQUEST_CONFIRMED=true` is set only after the user asks for commits. |
+| Report synthesis | The orchestrator loads the final report contract after commit execution or terminal failure. |

--- a/skills/committing-scoped-changes/flow-diagram.md
+++ b/skills/committing-scoped-changes/flow-diagram.md
@@ -113,3 +113,10 @@ Blockers:
 | Missing or ambiguous `CHANGE_PATHS` | Needs input |
 | No user commit request | Blocked |
 | State, planning, verification, or commit failure without safe recovery | Blocked or failure contract |
+
+Unresolved questions:
+
+| Question | Handling |
+| --- | --- |
+| Should scope expand beyond `CHANGE_PATHS`? | Ask before expanding. |
+| Should meaningful in-scope changes be left uncommitted? | Ask before leaving them behind. |

--- a/skills/committing-scoped-changes/flow-diagram.md
+++ b/skills/committing-scoped-changes/flow-diagram.md
@@ -105,3 +105,11 @@ Risks:
 | Unrelated work could be staged or committed accidentally | Executor stages only approved scoped groups and reviews staged diff before commit. |
 | Hooks or generated files can change the worktree | Orchestrator refreshes scoped state after each commit and replans if needed. |
 | Scope ambiguity can cause unsafe commits | Workflow stops for one targeted user question. |
+
+Blockers:
+
+| Blocker | Terminal State |
+| --- | --- |
+| Missing or ambiguous `CHANGE_PATHS` | Needs input |
+| No user commit request | Blocked |
+| State, planning, verification, or commit failure without safe recovery | Blocked or failure contract |

--- a/skills/committing-scoped-changes/flow-diagram.md
+++ b/skills/committing-scoped-changes/flow-diagram.md
@@ -39,9 +39,9 @@ flowchart TD
 
   COMMIT_NEXT --> EXEC_ACTIONS[Executor stages only group paths, reviews staged diff, runs verification, creates commit]
   EXEC_ACTIONS --> EXEC_RESULT{COMMIT_EXECUTE result}
-  EXEC_RESULT -->|VERIFY_FAILED| RECOVER{Safe in-scope recovery available and attempts remain?}
+  EXEC_RESULT -->|VERIFY_FAILED| RECOVER{Safe in-scope recovery available and under 3 attempts?}
   RECOVER -->|yes| COMMIT_NEXT
-  RECOVER -->|no| VERIFY_BLOCKED([Blocked: verification failure contract])
+  RECOVER -->|no| VERIFY_FAILED([VERIFY_FAILED: verification failure contract])
   EXEC_RESULT -->|COMMIT_ERROR or ERROR| EXEC_BLOCKED([Blocked: commit execution failure contract])
   EXEC_RESULT -->|PASS| RECORD_SHA[Record commit SHA and verification evidence]
 
@@ -66,7 +66,7 @@ flowchart TD
   class ASK_PATHS,ASK_CONTEXT,ASK_DECISION,HUMAN_SCOPE human;
   class FINAL_REPORT output;
   class DONE success;
-  class WAIT_PATHS,STOP_NO_AUTH,NO_CHANGES,WAIT_CONTEXT,STATE_BLOCKED,WAIT_DECISION,PLAN_BLOCKED,SCOPE_DECLINED,VERIFY_BLOCKED,EXEC_BLOCKED stop;
+  class WAIT_PATHS,STOP_NO_AUTH,NO_CHANGES,WAIT_CONTEXT,STATE_BLOCKED,WAIT_DECISION,PLAN_BLOCKED,SCOPE_DECLINED,VERIFY_FAILED,EXEC_BLOCKED stop;
 ```
 
 Readiness rule: commit execution is allowed only when `COMMIT_REQUEST_CONFIRMED=true`, `CHANGE_PATHS` is explicit, the planner has approved scoped commit groups, and any required human scope decision has an approve branch.

--- a/skills/committing-scoped-changes/flow-diagram.md
+++ b/skills/committing-scoped-changes/flow-diagram.md
@@ -18,7 +18,7 @@ flowchart TD
   STATE_RESULT -->|NO_SCOPED_CHANGES| NO_CHANGES([NO_SCOPED_CHANGES: report no commit-worthy scoped work])
   STATE_RESULT -->|NEEDS_CONTEXT| ASK_CONTEXT[Ask one targeted context question]
   ASK_CONTEXT --> WAIT_CONTEXT([Needs input: context])
-  STATE_RESULT -->|BLOCKED or ERROR| STATE_BLOCKED([Blocked: report state failure contract])
+  STATE_RESULT -->|BLOCKED or ERROR| STATE_BLOCKED([Blocked/Error: report state failure contract])
   STATE_RESULT -->|PASS| REF_NEED{Reference need named?}
 
   REF_NEED -->|yes| LOOKUP_REF[Load external-sources and select only relevant public URL]
@@ -28,21 +28,21 @@ flowchart TD
   PLAN --> PLAN_RESULT{COMMIT_PLAN result}
   PLAN_RESULT -->|NEEDS_DECISION| ASK_DECISION[Ask smallest user decision question]
   ASK_DECISION --> WAIT_DECISION([Needs input: decision])
-  PLAN_RESULT -->|BLOCKED or ERROR| PLAN_BLOCKED([Blocked: report planning failure contract])
+  PLAN_RESULT -->|BLOCKED or ERROR| PLAN_BLOCKED([Blocked/Error: report planning failure contract])
   PLAN_RESULT -->|PASS| APPROVE_GROUPS[Use approved commit groups, messages, and verification checks]
 
   APPROVE_GROUPS --> SENSITIVE_SCOPE{Plan expands scope or leaves meaningful in-scope changes uncommitted?}
   SENSITIVE_SCOPE -->|yes| HUMAN_SCOPE[Human gate: explain target, reason, risk, safer alternative, approve or decline]
   HUMAN_SCOPE -->|approved| COMMIT_NEXT[Dispatch scoped-commit-executor for next approved group]
   HUMAN_SCOPE -->|declined| SCOPE_DECLINED([Blocked: scope decision declined])
-  SENSITIVE_SCOPE -->|no| COMMIT_NEXT[Dispatch scoped-commit-executor for next approved group]
+  SENSITIVE_SCOPE -->|no| COMMIT_NEXT
 
   COMMIT_NEXT --> EXEC_ACTIONS[Executor stages only group paths, reviews staged diff, runs verification, creates commit]
   EXEC_ACTIONS --> EXEC_RESULT{COMMIT_EXECUTE result}
   EXEC_RESULT -->|VERIFY_FAILED| RECOVER{Safe in-scope recovery available and under 3 attempts?}
   RECOVER -->|yes| COMMIT_NEXT
   RECOVER -->|no| VERIFY_FAILED([VERIFY_FAILED: verification failure contract])
-  EXEC_RESULT -->|COMMIT_ERROR or ERROR| EXEC_BLOCKED([Blocked: commit execution failure contract])
+  EXEC_RESULT -->|COMMIT_ERROR or ERROR| EXEC_BLOCKED([Error: commit execution failure contract])
   EXEC_RESULT -->|PASS| RECORD_SHA[Record commit SHA and verification evidence]
 
   RECORD_SHA --> REFRESH[Refresh scoped state because hooks, generated files, or concurrent edits may change safety]
@@ -57,18 +57,16 @@ flowchart TD
   classDef decision fill:#f8f9fa,stroke:#495057,color:#000;
   classDef human fill:#f3e8ff,stroke:#6f42c1,color:#000;
   classDef output fill:#e8f5e9,stroke:#2e7d32,color:#000;
-  classDef success fill:#e8f5e9,stroke:#2e7d32,color:#000;
   classDef stop fill:#fdecea,stroke:#b02a37,color:#000;
 
   class HAS_PATHS,AUTH,STATE_RESULT,REF_NEED,PLAN_RESULT,SENSITIVE_SCOPE,EXEC_RESULT,RECOVER,REMAINING,MORE_GROUPS decision;
   class INTAKE,SET_SCOPE,DISPATCH_STATE,LOOKUP_REF,PLAN,APPROVE_GROUPS,EXEC_ACTIONS,RECORD_SHA,REFRESH check;
   class ASK_PATHS,ASK_CONTEXT,ASK_DECISION,HUMAN_SCOPE human;
-  class FINAL_REPORT output;
-  class DONE success;
+  class FINAL_REPORT,DONE output;
   class WAIT_PATHS,STOP_NO_AUTH,NO_CHANGES,WAIT_CONTEXT,STATE_BLOCKED,WAIT_DECISION,PLAN_BLOCKED,SCOPE_DECLINED,VERIFY_FAILED,EXEC_BLOCKED stop;
 ```
 
-Readiness rule: commit execution is allowed only when `COMMIT_REQUEST_CONFIRMED=true`, `CHANGE_PATHS` is explicit, the planner has approved scoped commit groups, and any required human scope decision has an approve branch.
+Readiness rule: commit execution is allowed only when `COMMIT_REQUEST_CONFIRMED=true`, `CHANGE_PATHS` is explicit, the planner has approved scoped commit groups, and the user has approved any required human scope decision.
 
 Final report contract: load
 [`./references/report-contract-orchestrator.md`](./references/report-contract-orchestrator.md)

--- a/skills/committing-scoped-changes/flow-diagram.md
+++ b/skills/committing-scoped-changes/flow-diagram.md
@@ -53,7 +53,6 @@ flowchart TD
   MORE_GROUPS -->|no| FINAL_REPORT[Load orchestrator report contract and synthesize final report]
   FINAL_REPORT --> DONE([Success: report SHAs, verification, remaining scoped changes, untouched unrelated work])
 
-  classDef guard fill:#fff3cd,stroke:#856404,color:#000;
   classDef check fill:#e7f1ff,stroke:#0b5ed7,color:#000;
   classDef decision fill:#f8f9fa,stroke:#495057,color:#000;
   classDef human fill:#f3e8ff,stroke:#6f42c1,color:#000;


### PR DESCRIPTION
## Summary

Adds a Mermaid flow diagram documenting the committing-scoped-changes orchestrator workflow, including intake gates, subagent dispatch paths, human approval points, and terminal outcomes.

## Key Changes

- Add `skills/committing-scoped-changes/flow-diagram.md` with overview, workflow chart, styling classes, and annotated decision nodes
- Document readiness rules, authority/scope facts, workflow assumptions, risk mitigations, terminal blockers, and unresolved scope questions

## Impact

- Improves skill discoverability and onboarding for contributors authoring or running the committing-scoped-changes workflow
- Documentation-only; no runtime or test changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition; no runtime logic changes, so risk is limited to potential workflow misinterpretation if the diagram/notes are inaccurate.
> 
> **Overview**
> Adds `skills/committing-scoped-changes/flow-diagram.md` documenting the *committing-scoped-changes* orchestrator as a Mermaid flowchart, including intake gates, subagent dispatch steps, human approval points, retries, and terminal states.
> 
> Also documents the readiness rule for when committing is allowed, and summarizes scope/authority facts, assumptions, risks/mitigations, blockers, and open scope questions, with a link to the final report contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6eaca11595881d023c52ff2c1f0ff0fb016e6b50. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->