### PR TITLE
docs(improve-skill-definition): add status contracts and stop/wait resume rules

### DIFF
--- a/skills/improve-skill-definition/SKILL.md
+++ b/skills/improve-skill-definition/SKILL.md
@@ -26,7 +26,9 @@ constraints.
 | `REFERENCE_NEED` | No | `"current Claude subagent guidance"` |
 
 If `SKILL_PATH` is missing, ask one focused question for the target path. Default
-to portable markdown-compatible skills when `TARGET_RUNTIME` is unspecified.
+to portable markdown-compatible skills when `TARGET_RUNTIME` is unspecified. When
+asking a required user question, stop and wait for the answer before resuming the
+relevant phase; do not treat the question itself as the final blocked handoff.
 
 ## Output Contract
 
@@ -75,6 +77,19 @@ optional improvements considered and rejected.
 Read a subagent file only when dispatching that subagent. Retain only its status,
 findings, file paths, fetched URLs, and concise summaries.
 
+## Status Contracts
+
+| Dispatch | Return statuses |
+| -------- | --------------- |
+| `skill-package-auditor` | `NO_CHANGE`, `MATERIAL_ISSUES`, `BLOCKED`, `ERROR` |
+| `skill-definition-editor` | `PASS`, `BLOCKED`, `ERROR` |
+| Repair `skill-definition-editor` | `PASS`, `BLOCKED`, `ERROR` |
+| `skill-package-validator` | `PASS`, `FAIL`, `BLOCKED`, `ERROR` |
+
+Each branch handles only the listed statuses. `BLOCKED` means ask the smallest
+focused question when a user decision can unblock the current phase; otherwise
+load `./references/final-report-template.md` and return the blocked handoff.
+
 ## Progressive Disclosure Map
 
 | Need | Load | When |
@@ -111,25 +126,32 @@ skill less reliable, less portable, or harder to maintain, do not make it.
 3. If the audit returns `NO_CHANGE`, stop without editing and report the no-op
    decision using `./references/final-report-template.md`.
 4. If the audit returns `BLOCKED`, ask the smallest needed question or report
-   the blocked decision using `./references/final-report-template.md`.
+   the blocked decision using `./references/final-report-template.md`. If a
+   question is needed for a safe verdict, stop and wait for the answer, then
+   resume audit with the new input.
 5. If the audit returns `ERROR`, report the error decision using
    `./references/final-report-template.md`.
 6. If the audit returns `MATERIAL_ISSUES`, confirm `SCOPE_LIMITS` allow the
    required fix. If they do not, ask one focused user decision about the
-   conflicting scope limit or report the blocked decision using
+   conflicting scope limit, stop and wait for the answer, then resume the scope
+   gate; otherwise report the blocked decision using
    `./references/final-report-template.md`.
 7. When scope allows the fix, dispatch `skill-definition-editor` with
    `SKILL_PATH`, `AUDIT_REPORT` limited to audited issues, affected files,
    minimal edit plan, scope limits,
    `CHECKLIST_PATH=./references/authoring-checklist.md`, and
    `EXTERNAL_SOURCES_PATH=./references/external-sources.md`.
-8. If the editor returns `BLOCKED` or `ERROR`, report the blocked or error
-   decision using `./references/final-report-template.md`.
+8. If the editor returns `BLOCKED`, ask one focused question for the editor
+   blocker, stop and wait for the answer, then re-dispatch the editor with the
+   new input. If the editor returns `ERROR`, report the error decision using
+   `./references/final-report-template.md`.
 9. If the editor returns `PASS`, dispatch `skill-package-validator` with
    `SKILL_PATH`, the original `AUDIT_REPORT`, `EDITOR_REPORT`, and
    `CHECKLIST_PATH=./references/authoring-checklist.md`.
-10. If validation returns `BLOCKED` or `ERROR`, report the blocked or error
-    decision using `./references/final-report-template.md`.
+10. If validation returns `BLOCKED`, ask one focused question for the validation
+    blocker, stop and wait for the answer, then re-run validation with the new
+    input. If validation returns `ERROR`, report the error decision using
+    `./references/final-report-template.md`.
 11. On validation `FAIL`, re-dispatch the editor with `SKILL_PATH`, the original
     `AUDIT_REPORT`, `VALIDATOR_FINDINGS` as the focused fix scope, scope limits,
     `CHECKLIST_PATH=./references/authoring-checklist.md`, and
@@ -138,8 +160,10 @@ skill less reliable, less portable, or harder to maintain, do not make it.
     `EDITOR_REPORT`, and `CHECKLIST_PATH=./references/authoring-checklist.md`.
     Use at most three targeted fix cycles. If validation still returns `FAIL`
     after the third targeted fix cycle, report a blocked decision with the
-    remaining validation findings and attempted repairs. If a repair edit or
-    revalidation returns `BLOCKED` or `ERROR`, report that decision using
+    remaining validation findings and attempted repairs. If a repair edit returns
+    `BLOCKED`, ask one focused question for the repair blocker, stop and wait for
+    the answer, then re-dispatch the repair. If a repair edit or revalidation
+    returns `ERROR`, report that decision using
     `./references/final-report-template.md`.
 12. Load `./references/final-report-template.md` and return the final handoff.
 

--- a/skills/improve-skill-definition/flow-diagram.md
+++ b/skills/improve-skill-definition/flow-diagram.md
@@ -1,86 +1,156 @@
 # Improve Skill Definition Flow
 
 This workflow is run by a skill-definition improvement orchestrator. The
-orchestrator normalizes inputs, dispatches focused subagents, and keeps only
-statuses, findings, file paths, fetched URLs, and concise summaries. Raw package
-inspection, editing, validation, and external-source lookup happen inside
-subagents or bundled references. Edits occur only after an evidence-backed
-material issue, and the package must remain standalone with relative bundled
-paths.
+orchestrator normalizes inputs, dispatches focused package subagents, and
+synthesizes concise decisions. It may read local bundled contracts, dispatch
+`skill-package-auditor`, `skill-definition-editor`, and
+`skill-package-validator`, ask one focused user question when blocked, and
+return a final handoff. Raw inspection, editing, validation, and external-source
+lookup stay inside subagents or bundled references. Edits occur only through
+`skill-definition-editor` after evidence-backed material issues and scope gate
+approval.
 
 ```mermaid
 flowchart TD
-  START([Start: improve existing skill package]) --> INTAKE[Normalize SKILL_PATH, known problem, runtime, scope, and reference need]
-  INTAKE --> PATH_OK{SKILL_PATH present and locatable?}
+  subgraph INTAKE_PHASE["Phase: Intake"]
+    START([Start: improve existing skill package])
+    INTAKE[Normalize SKILL_PATH, known problem, runtime, scope, and reference need]
+    PATH_OK{SKILL_PATH present and locatable?}
+    ASK_PATH[Ask one focused question for target path]
+    WAIT_PATH([Stop/wait: user provides SKILL_PATH])
+    RESUME_PATH[Resume with provided SKILL_PATH]
+    BOUNDARY[Set boundary: orchestrator keeps only verdicts, summaries, statuses, paths, fetched URLs, and user constraints]
+  end
 
-  PATH_OK -->|no| ASK_PATH[Ask one focused question for target path]
-  ASK_PATH --> LOAD_BLOCKED_TEMPLATE
+  subgraph AUDIT_PHASE["Phase: Audit"]
+    AUDIT_CONTRACT["Auditor status contract: NO_CHANGE / MATERIAL_ISSUES / BLOCKED / ERROR"]
+    AUDIT[Dispatch skill-package-auditor with ./references/authoring-checklist.md and optional ./references/external-sources.md]
+    AUDIT_STATUS{Audit status?}
+    SAFE_VERDICT_GATE{Safe verdict requires user decision?}
+    ASK_SAFE_VERDICT[Ask one focused question needed for safe verdict]
+    WAIT_SAFE_VERDICT([Stop/wait: user provides safe-verdict decision])
+    AUDIT_BLOCKED[Retain blocker and smallest escalation question]
+    AUDIT_ERROR[Retain error summary]
+    SCOPE_GATE{Scope limits allow required fix?}
+    ASK_SCOPE[Ask one focused user decision about conflicting scope limit]
+    WAIT_SCOPE([Stop/wait: user resolves scope conflict])
+  end
 
-  PATH_OK -->|yes| BOUNDARY[Set boundary: orchestrator does not inspect raw target files, edit, validate, or fetch sources directly]
-  BOUNDARY --> AUDIT[Dispatch skill-package-auditor with checklist path and optional external sources path]
+  subgraph EDIT_PHASE["Phase: Edit"]
+    EDIT_CONTRACT["Editor status contract: PASS / BLOCKED / ERROR"]
+    EDIT[Dispatch skill-definition-editor with audited issues, affected files, minimal edit plan, and scope limits]
+    EDIT_STATUS{Edit status?}
+    ASK_EDIT_BLOCKER[Ask one focused question for editor blocker]
+    WAIT_EDIT_BLOCKER([Stop/wait: user resolves editor blocker])
+    EDIT_ERROR[Retain edit error summary]
+    REPAIR_CONTRACT["Repair editor status contract: PASS / BLOCKED / ERROR"]
+    REPAIR[Re-dispatch editor with original required inputs and validator findings as fix scope]
+    REPAIR_STATUS{Repair edit status?}
+    ASK_REPAIR_BLOCKER[Ask one focused question for repair blocker]
+    WAIT_REPAIR_BLOCKER([Stop/wait: user resolves repair blocker])
+    REPAIR_ERROR[Retain repair error summary]
+  end
 
-  AUDIT --> AUDIT_STATUS{Audit status?}
-  AUDIT_STATUS -->|NO_CHANGE| LOAD_NO_CHANGE_TEMPLATE[Load final-report-template]
-  LOAD_NO_CHANGE_TEMPLATE --> NO_CHANGE([Decision: no change])
+  subgraph VALIDATE_PHASE["Phase: Validate"]
+    VALIDATOR_CONTRACT["Validator status contract: PASS / FAIL / BLOCKED / ERROR"]
+    VALIDATE[Dispatch skill-package-validator with package path, audit report, editor report, and checklist path]
+    VALIDATION_STATUS{Validation status?}
+    RETRY_GATE{Targeted repair cycles used fewer than 3?}
+    ASK_VALIDATION_BLOCKER[Ask one focused question for validation blocker]
+    WAIT_VALIDATION_BLOCKER([Stop/wait: user resolves validation blocker])
+    VALIDATION_ERROR[Retain validation error summary]
+    ESCALATE_FAIL[Retain failed checks, repair attempts, and remaining risks]
+  end
 
-  AUDIT_STATUS -->|MATERIAL_ISSUES| SCOPE_GATE{Scope limits allow required fix?}
-  AUDIT_STATUS -->|BLOCKED| SAFE_VERDICT_GATE{Safe verdict requires user decision?}
-  AUDIT_STATUS -->|ERROR| AUDIT_ERROR[Retain error summary]
+  subgraph HANDOFF_PHASE["Phase: Handoff"]
+    LOAD_NO_CHANGE_TEMPLATE[Load ./references/final-report-template.md]
+    LOAD_CHANGED_TEMPLATE[Load ./references/final-report-template.md]
+    LOAD_BLOCKED_TEMPLATE[Load ./references/final-report-template.md]
+    LOAD_ERROR_TEMPLATE[Load ./references/final-report-template.md]
+    HANDOFF_NO_CHANGE[Return concise handoff with evidence, rejected optional improvements, and validation limits]
+    HANDOFF_CHANGED[Return concise handoff with material issues, files changed, validation, resources, and risks]
+    HANDOFF_BLOCKED[Return concise blocked handoff with reason, question, and completed checks]
+    HANDOFF_ERROR[Return concise error handoff with failed condition and known context]
+    NO_CHANGE([Decision: no change])
+    CHANGED([Decision: changed])
+    BLOCKED([Decision: blocked])
+    ERROR([Decision: error])
+  end
 
-  SAFE_VERDICT_GATE -->|yes| ASK_SAFE_VERDICT[Ask one focused question needed for safe verdict]
-  SAFE_VERDICT_GATE -->|no| AUDIT_BLOCKED[Retain blocker and smallest escalation question]
-  ASK_SAFE_VERDICT --> LOAD_BLOCKED_TEMPLATE
+  START --> INTAKE
+  INTAKE --> PATH_OK
+  PATH_OK -->|no| ASK_PATH
+  ASK_PATH --> WAIT_PATH
+  WAIT_PATH -.->|user replies| RESUME_PATH
+  RESUME_PATH --> INTAKE
+  PATH_OK -->|yes| BOUNDARY
 
-  AUDIT_BLOCKED --> LOAD_BLOCKED_TEMPLATE[Load final-report-template]
-  LOAD_BLOCKED_TEMPLATE --> BLOCKED([Decision: blocked])
+  BOUNDARY --> AUDIT_CONTRACT
+  AUDIT_CONTRACT --> AUDIT
+  AUDIT --> AUDIT_STATUS
+  AUDIT_STATUS -->|NO_CHANGE| LOAD_NO_CHANGE_TEMPLATE
+  AUDIT_STATUS -->|MATERIAL_ISSUES| SCOPE_GATE
+  AUDIT_STATUS -->|BLOCKED| SAFE_VERDICT_GATE
+  AUDIT_STATUS -->|ERROR| AUDIT_ERROR
 
-  AUDIT_ERROR --> LOAD_ERROR_TEMPLATE[Load final-report-template]
-  LOAD_ERROR_TEMPLATE --> ERROR([Decision: error])
+  SAFE_VERDICT_GATE -->|yes| ASK_SAFE_VERDICT
+  ASK_SAFE_VERDICT --> WAIT_SAFE_VERDICT
+  WAIT_SAFE_VERDICT -.->|user replies| AUDIT
+  SAFE_VERDICT_GATE -->|no| AUDIT_BLOCKED
 
-  SCOPE_GATE -->|no| ASK_SCOPE[Ask one focused user decision about the conflicting scope limit]
-  ASK_SCOPE --> LOAD_BLOCKED_TEMPLATE
+  SCOPE_GATE -->|no| ASK_SCOPE
+  ASK_SCOPE --> WAIT_SCOPE
+  WAIT_SCOPE -.->|user replies| SCOPE_GATE
+  SCOPE_GATE -->|yes| EDIT_CONTRACT
 
-  SCOPE_GATE -->|yes| EDIT[Dispatch skill-definition-editor with audited issues, affected files, minimal edit plan, and scope limits]
-  EDIT --> EDIT_STATUS{Edit status?}
+  EDIT_CONTRACT --> EDIT
+  EDIT --> EDIT_STATUS
+  EDIT_STATUS -->|PASS| VALIDATOR_CONTRACT
+  EDIT_STATUS -->|BLOCKED| ASK_EDIT_BLOCKER
+  ASK_EDIT_BLOCKER --> WAIT_EDIT_BLOCKER
+  WAIT_EDIT_BLOCKER -.->|user replies| EDIT
+  EDIT_STATUS -->|ERROR| EDIT_ERROR
 
-  EDIT_STATUS -->|PASS| VALIDATE[Dispatch skill-package-validator with package path, audit report, editor report, and checklist path]
-  EDIT_STATUS -->|BLOCKED| EDIT_BLOCKED[Retain edit blocker and smallest escalation question]
-  EDIT_STATUS -->|ERROR| EDIT_ERROR[Retain edit error summary]
+  VALIDATOR_CONTRACT --> VALIDATE
+  VALIDATE --> VALIDATION_STATUS
+  VALIDATION_STATUS -->|PASS| LOAD_CHANGED_TEMPLATE
+  VALIDATION_STATUS -->|FAIL| RETRY_GATE
+  VALIDATION_STATUS -->|BLOCKED| ASK_VALIDATION_BLOCKER
+  ASK_VALIDATION_BLOCKER --> WAIT_VALIDATION_BLOCKER
+  WAIT_VALIDATION_BLOCKER -.->|user replies| VALIDATE
+  VALIDATION_STATUS -->|ERROR| VALIDATION_ERROR
 
-  EDIT_BLOCKED --> LOAD_BLOCKED_TEMPLATE
-  EDIT_ERROR --> LOAD_ERROR_TEMPLATE
-
-  VALIDATE --> VALIDATION_STATUS{Validation status?}
-  VALIDATION_STATUS -->|PASS| LOAD_CHANGED_TEMPLATE[Load final-report-template]
-  LOAD_CHANGED_TEMPLATE --> CHANGED([Decision: changed])
-
-  VALIDATION_STATUS -->|FAIL| RETRY_GATE{Targeted repair cycles used fewer than 3?}
-  RETRY_GATE -->|yes| REPAIR[Re-dispatch editor with original required inputs and validator findings as fix scope]
-  REPAIR --> REPAIR_STATUS{Repair edit status?}
+  RETRY_GATE -->|yes| REPAIR_CONTRACT
+  REPAIR_CONTRACT --> REPAIR
+  REPAIR --> REPAIR_STATUS
   REPAIR_STATUS -->|PASS| VALIDATE
-  REPAIR_STATUS -->|BLOCKED| REPAIR_BLOCKED[Retain repair blocker and smallest escalation question]
-  REPAIR_STATUS -->|ERROR| REPAIR_ERROR[Retain repair error summary]
-  REPAIR_BLOCKED --> LOAD_BLOCKED_TEMPLATE
-  REPAIR_ERROR --> LOAD_ERROR_TEMPLATE
+  REPAIR_STATUS -->|BLOCKED| ASK_REPAIR_BLOCKER
+  ASK_REPAIR_BLOCKER --> WAIT_REPAIR_BLOCKER
+  WAIT_REPAIR_BLOCKER -.->|user replies| REPAIR
+  REPAIR_STATUS -->|ERROR| REPAIR_ERROR
+  RETRY_GATE -->|no| ESCALATE_FAIL
 
-  RETRY_GATE -->|no| ESCALATE_FAIL[Retain failed checks, repair attempts, and remaining risks]
+  AUDIT_BLOCKED --> LOAD_BLOCKED_TEMPLATE
+  AUDIT_ERROR --> LOAD_ERROR_TEMPLATE
+  EDIT_ERROR --> LOAD_ERROR_TEMPLATE
+  REPAIR_ERROR --> LOAD_ERROR_TEMPLATE
+  VALIDATION_ERROR --> LOAD_ERROR_TEMPLATE
   ESCALATE_FAIL --> LOAD_BLOCKED_TEMPLATE
 
-  VALIDATION_STATUS -->|BLOCKED| VALIDATION_BLOCKED[Retain validation blocker and smallest escalation question]
-  VALIDATION_STATUS -->|ERROR| VALIDATION_ERROR[Retain validation error summary]
-
-  VALIDATION_BLOCKED --> LOAD_BLOCKED_TEMPLATE
-  VALIDATION_ERROR --> LOAD_ERROR_TEMPLATE
-
-  NO_CHANGE --> HANDOFF[Return concise handoff with evidence, rejected optional improvements, and validation limits]
-  CHANGED --> HANDOFF_CHANGED[Return concise handoff with material issues, files changed, validation, resources, and risks]
-  BLOCKED --> HANDOFF_BLOCKED[Return concise blocked handoff with reason, question, and completed checks]
-  ERROR --> HANDOFF_ERROR[Return concise error handoff with failed condition and known context]
+  LOAD_NO_CHANGE_TEMPLATE --> HANDOFF_NO_CHANGE
+  LOAD_CHANGED_TEMPLATE --> HANDOFF_CHANGED
+  LOAD_BLOCKED_TEMPLATE --> HANDOFF_BLOCKED
+  LOAD_ERROR_TEMPLATE --> HANDOFF_ERROR
+  HANDOFF_NO_CHANGE --> NO_CHANGE
+  HANDOFF_CHANGED --> CHANGED
+  HANDOFF_BLOCKED --> BLOCKED
+  HANDOFF_ERROR --> ERROR
 
   classDef guard fill:#fff3cd,stroke:#856404,color:#000;
   classDef check fill:#e7f1ff,stroke:#0b5ed7,color:#000;
   classDef decision fill:#f8f9fa,stroke:#495057,color:#000;
   classDef human fill:#f3e8ff,stroke:#6f42c1,color:#000;
+  classDef wait fill:#fff3cd,stroke:#856404,color:#000;
   classDef output fill:#e8f5e9,stroke:#2e7d32,color:#000;
   classDef success fill:#e8f5e9,stroke:#2e7d32,color:#000;
   classDef stop fill:#fdecea,stroke:#b02a37,color:#000;
@@ -88,16 +158,18 @@ flowchart TD
   class PATH_OK,AUDIT_STATUS,SAFE_VERDICT_GATE,SCOPE_GATE,EDIT_STATUS,VALIDATION_STATUS,RETRY_GATE,REPAIR_STATUS decision;
   class BOUNDARY,SAFE_VERDICT_GATE,SCOPE_GATE,RETRY_GATE guard;
   class AUDIT,EDIT,VALIDATE,REPAIR check;
-  class ASK_PATH,ASK_SAFE_VERDICT,ASK_SCOPE human;
-  class LOAD_NO_CHANGE_TEMPLATE,LOAD_CHANGED_TEMPLATE,LOAD_BLOCKED_TEMPLATE,LOAD_ERROR_TEMPLATE,HANDOFF,HANDOFF_CHANGED,HANDOFF_BLOCKED,HANDOFF_ERROR output;
+  class ASK_PATH,ASK_SAFE_VERDICT,ASK_SCOPE,ASK_EDIT_BLOCKER,ASK_REPAIR_BLOCKER,ASK_VALIDATION_BLOCKER human;
+  class WAIT_PATH,WAIT_SAFE_VERDICT,WAIT_SCOPE,WAIT_EDIT_BLOCKER,WAIT_REPAIR_BLOCKER,WAIT_VALIDATION_BLOCKER wait;
+  class LOAD_NO_CHANGE_TEMPLATE,LOAD_CHANGED_TEMPLATE,LOAD_BLOCKED_TEMPLATE,LOAD_ERROR_TEMPLATE,HANDOFF_NO_CHANGE,HANDOFF_CHANGED,HANDOFF_BLOCKED,HANDOFF_ERROR output;
   class NO_CHANGE,CHANGED success;
-  class BLOCKED,ERROR,AUDIT_BLOCKED,AUDIT_ERROR,EDIT_BLOCKED,EDIT_ERROR,REPAIR_BLOCKED,REPAIR_ERROR,VALIDATION_BLOCKED,VALIDATION_ERROR,ESCALATE_FAIL stop;
+  class BLOCKED,ERROR,AUDIT_BLOCKED,AUDIT_ERROR,EDIT_ERROR,REPAIR_ERROR,VALIDATION_ERROR,ESCALATE_FAIL stop;
 ```
 
-Readiness rule: A final handoff is ready only after `final-report-template.md` is
-loaded and the outcome is one of `changed`, `no change`, `blocked`, or `error`.
-Failed validation may trigger at most three targeted editor and validator repair
-cycles. If validation still returns `FAIL` after the third cycle, report a
-blocked decision with remaining findings and attempted repairs. Repair dispatches
-preserve required editor inputs while using validator findings as the focused
-fix scope.
+Readiness rule: A final handoff is ready only after
+`./references/final-report-template.md` is loaded and the outcome is one of
+`changed`, `no change`, `blocked`, or `error`. User-question branches stop and
+wait for the requested answer before resuming the relevant phase; they are not
+the same operation as returning a blocked handoff. Failed validation may trigger
+at most three targeted editor and validator repair cycles. If validation still
+returns `FAIL` after the third cycle, report a blocked decision with remaining
+findings and attempted repairs.


### PR DESCRIPTION
## Summary

This PR hardens the `improve-skill-definition` skill orchestration so blocked subagent statuses pause for user input and resume the relevant phase instead of returning a premature final handoff. The flow diagram is restructured into intake, audit, edit, validate, and handoff phases with explicit stop/wait nodes that mirror the new SKILL.md status contracts.

## Key Changes

- Add a **Status Contracts** table mapping each subagent dispatch to its return statuses (`NO_CHANGE`, `MATERIAL_ISSUES`, `BLOCKED`, `ERROR`, `PASS`, `FAIL`).
- Clarify stop/wait/resume behavior across audit, scope gate, editor, validator, and repair paths in `SKILL.md`.
- Restructure `flow-diagram.md` into phased Mermaid subgraphs with explicit stop/wait nodes and status-contract labels.

## Impact

- Orchestrators running this skill will pause correctly on blockers and resume the right phase after user input.
- No runtime migration required; documentation-only change to the skill package.
- Untracked local files (`updated-prompt.md`, `root-cause-analysis-flow*.md`) are **not** included in this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only changes that clarify orchestration control flow; risk is limited to potentially shifting operator expectations of `BLOCKED` handling if interpreted incorrectly.
> 
> **Overview**
> Hardens the `improve-skill-definition` orchestration docs so `BLOCKED` paths **ask one focused question, stop/wait for the reply, and then resume the relevant phase** (audit, scope gate, edit, validation, or repair) instead of treating the question as the final handoff.
> 
> Adds an explicit **status-contract table** for auditor/editor/validator dispatches in `SKILL.md`, and restructures `flow-diagram.md` into phased Mermaid subgraphs with stop/wait nodes and contract labels to mirror the updated control flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd36cc818926154b30b1d1f686c9db8855bfcc5b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->