### PR TITLE
docs(refine-task): route REVIEW verdicts and evidence classification

### DIFF
--- a/skills/refine-task/SKILL.md
+++ b/skills/refine-task/SKILL.md
@@ -32,11 +32,12 @@ for one source item.
 ## Workflow Overview
 
 ```text
-1. Normalize inputs and detect write intent.
-2. Dispatch refinement-reviewer with compact source pointers and user intent.
-3. Branch on the returned structured status.
-4. Post only when WRITE_MODE=post-comment, posting is available, and the reviewer returned POST_ALLOWED=yes.
-5. If the reviewer returns `Comment mode=Ready to post` and the coordinator does not post, return `Mode: Ready to post`; otherwise return the reviewer Mode, Status, and Comment.
+1. Normalize inputs, set reviewer-only authority, and detect write intent.
+2. Defer tracker mutations beyond one new refinement comment.
+3. Build a compact source snapshot, classify missing evidence, and block only when missing access or source context prevents review.
+4. Dispatch refinement-reviewer with compact pointers, user intent, approvals, mutation limits, and bundled reference paths.
+5. Route the returned `REVIEW`, `REVIEW_STATUS`, `Comment mode`, and `POST_ALLOWED` before choosing output mode.
+6. Post only the exact returned comment once when WRITE_MODE=post-comment, posting is available, and POST_ALLOWED=yes.
 ```
 
 ## Subagent Registry
@@ -83,9 +84,10 @@ QUALITY_CHECKLIST_PATH: ../references/review-quality-checklist.md
 EXTERNAL_SOURCES_PATH: ../references/external-sources.md
 ```
 
-Keep only the returned `REVIEW_STATUS`, `POST_ALLOWED`, `Comment mode` (`Draft`,
-`Ready to post`, `Blocked`, or `Deferred`), blocked reason if any, and final
-comment or draft. Do not keep raw tracker payloads, long source text, or full
+Keep only the returned `REVIEW` (`PASS`, `BLOCKED`, `FAIL`, or `ERROR`),
+`REVIEW_STATUS`, `POST_ALLOWED`, `Comment mode` (`Draft`, `Ready to post`,
+`Blocked`, or `Deferred`), blocked reason if any, final comment or draft, and
+validation summary. Do not keep raw tracker payloads, long source text, or full
 analysis notes in coordinator context.
 
 ## Output Contract
@@ -97,10 +99,13 @@ Refinement review complete.
 Mode: Draft | Ready to post | Posted | Blocked | Deferred
 Status: Ready | Needs refinement | Needs split | Needs spike | Blocked | Not actionable
 Comment: <final comment or draft>
+Validation: <quality checklist summary, post failure reason, or remaining risk>
 ```
 
 Use `Posted` only after the coordinator successfully posts the exact refinement
-comment returned by the reviewer.
+comment returned by the reviewer. If posting fails, do not retry automatically;
+return `Mode: Ready to post` or `Mode: Blocked` with the exact unposted comment
+and the failure reason.
 
 Use `Ready to post` when the reviewer returns `Comment mode=Ready to post` but
 the coordinator does not post it, such as draft or unknown write mode, or a safe
@@ -109,6 +114,10 @@ post-comment run where posting is not performed.
 If the reviewer reports a mutation-only request with no refinement review to
 perform, return `Mode: Deferred` and explain that the mutation belongs in a
 separate approved workflow.
+
+If the reviewer returns `REVIEW=BLOCKED`, `REVIEW=FAIL`, or `REVIEW=ERROR`,
+return `Mode: Blocked`, preserve the safest returned comment when available, and
+include the blocked reason, failed checks, or error category in `Validation`.
 
 ## Escalation
 
@@ -120,12 +129,16 @@ If a gate is unavailable during an autonomous run, keep the safe reviewer-only
 path: return a draft, ask a neutral question in the comment, and defer sensitive
 recommendations.
 
+If posting fails after the exact comment is submitted once, stop with the safe
+reviewer-only path: return the exact unposted comment and the post failure
+reason without retrying into duplicate side effects.
+
 ## Example
 
 <example>
 Input: `Review https://github.com/acme/app/issues/42 for readiness and draft a refinement comment.`
 
 Flow: normalize `ITEM_URL`, dispatch `refinement-reviewer` with
-`WRITE_MODE=draft`, receive `REVIEW_STATUS=Needs refinement` and
-`Comment mode=Draft`, then return the draft comment.
+`WRITE_MODE=draft`, receive `REVIEW=PASS`, `REVIEW_STATUS=Needs refinement`,
+`Comment mode=Draft`, and validation summary, then return the draft comment.
 </example>

--- a/skills/refine-task/flow-diagram.md
+++ b/skills/refine-task/flow-diagram.md
@@ -1,78 +1,102 @@
 # refine-task reviewer-only refinement flow
 
-This workflow keeps the coordinator thin and evidence-focused: it normalizes a Jira ticket, Jira epic, GitHub issue, or GitHub parent issue request; dispatches `refinement-reviewer` with compact source pointers; and returns or posts exactly one refinement comment only when posting is explicitly authorized and available. Tracker items are treated as evidence to review, not state to mutate; all edits, lifecycle changes, child creation, link changes, splitting actions, and other mutations are deferred to separate approved workflows.
+This workflow keeps the coordinator thin and evidence-focused. It normalizes a Jira ticket, Jira epic, GitHub issue, or GitHub epic-style parent issue request; writes the review intent; collects compact evidence pointers; dispatches `refinement-reviewer`; and returns or posts exactly one refinement comment. Tracker items are evidence to review, not state to mutate. The coordinator may post one new comment only when posting is explicitly requested, tooling is available, and `POST_ALLOWED=yes`.
 
 ```mermaid
 flowchart TD
-  START(["Start: refine-task refinement request"]) --> INTAKE["Normalize inputs: ITEM_URL preferred, ITEM_CONTEXT optional, WRITE_MODE, HUMAN_APPROVALS, reference paths"]
-  INTAKE --> SOURCE_AVAILABLE{"Source item available?"}
-  SOURCE_AVAILABLE -->|no| ASK_SOURCE["Ask one concise question for source item or usable context"]
-  ASK_SOURCE --> BLOCKED_SOURCE(["Blocked: no source item or context"])
+  START(["Start: refine-task refinement request"]) --> INTAKE["Normalize inputs: ITEM_URL preferred, ITEM_CONTEXT optional, WRITE_MODE, HUMAN_APPROVALS, bundled reference paths"]
+  INTAKE --> ROLE_BOUNDARY["Set reviewer-only authority: normalize context, collect compact pointers, dispatch reviewer, return or post one refinement comment"]
+  ROLE_BOUNDARY --> SOURCE_AVAILABLE{"Source item or usable context available?"}
+
+  SOURCE_AVAILABLE -->|no| ASK_SOURCE["Ask one concise question for ITEM_URL or usable ITEM_CONTEXT"]
+  ASK_SOURCE --> BLOCKED_SOURCE(["Blocked: no source item or usable context"])
   SOURCE_AVAILABLE -->|yes| WRITE_INTENT["Detect write intent: draft, post-comment, or unknown"]
 
-  WRITE_INTENT --> MUTATION_ONLY{"Request is mutation-only or outside comment review?"}
-  MUTATION_ONLY -->|yes| DEFER_MUTATION(["Deferred: route tracker mutations to separate approved workflow"])
-  MUTATION_ONLY -->|no| POSTING_CLARITY{"Posting intent and tooling clear if posting requested?"}
-  POSTING_CLARITY -->|not posting requested| COLLECT_POINTERS["Collect compact evidence pointers: item body, comments, subtasks, linked items, docs, code references"]
-  POSTING_CLARITY -->|yes| COLLECT_POINTERS
-  POSTING_CLARITY -->|no| ASK_POSTING["Ask one concise question about posting authorization or tooling"]
+  WRITE_INTENT --> MUTATION_ONLY{"Request asks for tracker mutation beyond one new comment?"}
+  MUTATION_ONLY -->|yes| DEFER_MUTATION(["Deferred: route metadata edits, body edits, lifecycle changes, child creation, links, splits, and other mutations to a separate approved workflow"])
+  MUTATION_ONLY -->|no| POST_INTENT{"Posting requested?"}
+
+  POST_INTENT -->|no| SNAPSHOT["Build compact source snapshot: body, comments, subtasks, linked items, docs, code references, and source timestamps when available"]
+  POST_INTENT -->|yes| POST_PRECHECK{"Posting authorization and tooling clear?"}
+  POST_PRECHECK -->|no| ASK_POSTING["Ask one concise question about posting authorization or tooling"]
   ASK_POSTING --> BLOCKED_POSTING(["Blocked: posting authorization or access unclear"])
+  POST_PRECHECK -->|yes| SNAPSHOT
 
-  COLLECT_POINTERS --> ACCESS_OK{"Required evidence accessible?"}
-  ACCESS_OK -->|no| BLOCKED_ACCESS(["Blocked: missing access prevents review"])
-  ACCESS_OK -->|yes| DISPATCH["Dispatch refinement-reviewer with compact source pointers, user intent, and bundled reference paths"]
+  SNAPSHOT --> CLASSIFY_EVIDENCE["Classify missing evidence: non-blocking gaps, unsupported technical claims, contradictions, or missing access/source context"]
+  CLASSIFY_EVIDENCE --> ACCESS_GATE{"Missing access or source context blocks review?"}
+  ACCESS_GATE -->|yes| BLOCKED_ACCESS(["Blocked: missing access or source context prevents review"])
+  ACCESS_GATE -->|no| DISPATCH["Dispatch refinement-reviewer with compact pointers, write intent, approvals, mutation limits, and bundled reference paths"]
 
-  DISPATCH --> REVIEWER_POLICY["Reviewer loads policy references progressively and confirms boundaries, gates, and phase order"]
-  REVIEWER_POLICY --> READINESS_CHECKS["Run readiness checks: objective, scope, acceptance criteria, dependencies, risks, delivery shape, evidence gaps"]
-  READINESS_CHECKS --> TECH_CLAIMS{"Technical claims need verification?"}
-  TECH_CLAIMS -->|yes| VERIFY_CLAIMS["Verify against trusted official docs or codebase evidence"]
-  TECH_CLAIMS -->|no| CLASSIFY
-  VERIFY_CLAIMS --> CLASSIFY["Classify REVIEW_STATUS: Ready, Needs refinement, Needs split, Needs spike, Blocked, or Not actionable"]
+  DISPATCH --> REVIEW_POLICY["Reviewer loads policy references progressively and confirms boundaries, gates, phase order, and evidence standard"]
+  REVIEW_POLICY --> READINESS_CHECKS["Run readiness checks: objective, scope, acceptance criteria, dependencies, risks, delivery shape, evidence gaps"]
+  READINESS_CHECKS --> TECH_CLAIMS{"Technical claims present?"}
+  TECH_CLAIMS -->|yes| VERIFY_CLAIMS["Verify claims against trusted official docs or codebase evidence"]
+  TECH_CLAIMS -->|no| STATUS_CLASSIFY
+  VERIFY_CLAIMS --> CLAIMS_SUPPORTED{"Required claim evidence found?"}
+  CLAIMS_SUPPORTED -->|no| MARK_GAP["Mark as evidence gap, neutral question, spike need, or blocker based on impact"]
+  CLAIMS_SUPPORTED -->|yes| STATUS_CLASSIFY
+  MARK_GAP --> STATUS_CLASSIFY["Classify REVIEW_STATUS: Ready, Needs refinement, Needs split, Needs spike, Blocked, or Not actionable"]
 
-  CLASSIFY --> SENSITIVE_REC{"Sensitive recommendation would materially change comment?"}
+  STATUS_CLASSIFY --> SENSITIVE_REC{"Sensitive lifecycle, split, spike, security, data, permissions, migration, customer-impact, or operational recommendation would be stated?"}
   SENSITIVE_REC -->|yes| APPROVAL_AVAILABLE{"Human approval available?"}
-  APPROVAL_AVAILABLE -->|approved| INCLUDE_REC["Include approved recommendation with rationale and safer path"]
-  APPROVAL_AVAILABLE -->|declined| NEUTRALIZE_REC["Convert recommendation to neutral question or defer it"]
-  APPROVAL_AVAILABLE -->|missing| ASK_APPROVAL["Ask one concise question or avoid the gated recommendation"]
-  ASK_APPROVAL --> NEUTRALIZE_REC
+  APPROVAL_AVAILABLE -->|approved| INCLUDE_REC["Include approved recommendation with rationale, target, risk, reversibility, and safer alternative"]
+  APPROVAL_AVAILABLE -->|declined| NEUTRALIZE_REC["Convert to neutral question or defer recommendation"]
+  APPROVAL_AVAILABLE -->|missing| ASK_OR_DEFER["Ask one concise approval question or avoid the gated recommendation"]
+  ASK_OR_DEFER --> NEUTRALIZE_REC
   SENSITIVE_REC -->|no| ASSEMBLE_COMMENT
   INCLUDE_REC --> ASSEMBLE_COMMENT
-  NEUTRALIZE_REC --> ASSEMBLE_COMMENT["Assemble exactly one refinement comment or draft using the comment template"]
+  NEUTRALIZE_REC --> ASSEMBLE_COMMENT["Assemble exactly one refinement comment using evidence-backed findings, actionable gaps, questions, and validation summary"]
 
-  ASSEMBLE_COMMENT --> QUALITY_CHECK["Run review quality checklist: evidence support, actionable gaps, boundary compliance, no unsupported claims"]
+  ASSEMBLE_COMMENT --> QUALITY_CHECK["Run quality checklist: evidence support, actionable gaps, boundary compliance, no unsupported claims, single-comment output"]
   QUALITY_CHECK --> QUALITY_PASS{"Quality checklist passes?"}
-  QUALITY_PASS -->|no| FIX_CYCLE["Run targeted fix cycle without expanding scope"]
+  QUALITY_PASS -->|yes| REVIEW_RETURN["Reviewer returns REVIEW, REVIEW_STATUS, POST_ALLOWED, Comment mode, final comment, and validation summary"]
+  QUALITY_PASS -->|no| FIX_COUNT{"Fewer than 3 targeted fix cycles used?"}
+  FIX_COUNT -->|yes| FIX_CYCLE["Fix only failed checks without expanding scope"]
   FIX_CYCLE --> QUALITY_CHECK
-  QUALITY_PASS -->|yes| REVIEW_RETURN["Reviewer returns compact REVIEW, REVIEW_STATUS, POST_ALLOWED, Comment mode, final comment, and validation"]
+  FIX_COUNT -->|no| REVIEW_FAIL["Return REVIEW=FAIL with failed checks, final safe comment or reason unavailable, and validation summary"]
+  REVIEW_FAIL --> REVIEW_RETURN
 
-  REVIEW_RETURN --> COORDINATOR_KEEP["Coordinator retains only verdict fields and final comment; keeps raw payloads and long analysis out of top-level context"]
-  COORDINATOR_KEEP --> MODE_DECISION{"Output mode?"}
+  REVIEW_RETURN --> REVIEW_ROUTER{"REVIEW value?"}
+  REVIEW_ROUTER -->|ERROR| ERROR_OUT(["Blocked: reviewer error, return reason and no tracker mutation"])
+  REVIEW_ROUTER -->|FAIL| FAIL_OUT(["Blocked: quality failures remain after bounded fix loop"])
+  REVIEW_ROUTER -->|BLOCKED| BLOCKED_OUT(["Blocked: return reviewer status, reason, and comment if available"])
+  REVIEW_ROUTER -->|PASS| FIELD_ROUTER["Route by REVIEW_STATUS, Comment mode, and POST_ALLOWED before output"]
 
-  MODE_DECISION -->|draft or unknown| DRAFT_READY_MODE{"Comment mode=Ready to post?"}
-  DRAFT_READY_MODE -->|yes| READY_TO_POST_OUT(["Ready to post: return Refinement review complete with Mode, Status, and Comment"])
-  DRAFT_READY_MODE -->|no| DRAFT_OUT(["Draft: return Refinement review complete with Mode, Status, and Comment"])
-  MODE_DECISION -->|post-comment requested| POST_ALLOWED_GATE{"POST_ALLOWED=yes?"}
-  POST_ALLOWED_GATE -->|yes| POST_AVAILABLE{"Posting available?"}
-  POST_ALLOWED_GATE -->|no| RETURN_REVIEWER_MODE(["Return reviewer Mode, Status, and Comment without posting"])
-  POST_AVAILABLE -->|yes| POST_COMMENT["Post only the returned refinement comment"]
+  FIELD_ROUTER --> COORDINATOR_KEEP["Coordinator retains only verdict fields and final comment; raw payloads and long analysis stay out of coordinator context"]
+  COORDINATOR_KEEP --> MODE_DECISION{"WRITE_MODE?"}
+
+  MODE_DECISION -->|draft or unknown| DRAFT_MODE{"Comment mode?"}
+  DRAFT_MODE -->|Draft| DRAFT_OUT(["Draft: return Mode, REVIEW_STATUS, final comment, and validation summary"])
+  DRAFT_MODE -->|Ready to post| READY_TO_POST_OUT(["Ready to post: return Mode, REVIEW_STATUS, final comment, and validation summary"])
+  DRAFT_MODE -->|Blocked| BLOCKED_OUT
+  DRAFT_MODE -->|Deferred| DEFERRED_OUT(["Deferred: return reason, status, final comment if available, and no tracker mutation"])
+
+  MODE_DECISION -->|post-comment| POST_ALLOWED_GATE{"POST_ALLOWED=yes?"}
+  POST_ALLOWED_GATE -->|no| RETURN_REVIEWER_MODE["Do not post; return reviewer Comment mode, REVIEW_STATUS, final comment, and reason"]
+  RETURN_REVIEWER_MODE --> DRAFT_MODE
+  POST_ALLOWED_GATE -->|yes| POST_AVAILABLE{"Posting tooling available?"}
   POST_AVAILABLE -->|no| READY_TO_POST_OUT
-  POST_COMMENT --> POSTED_OUT(["Posted: return Refinement review complete with Mode, Status, and Comment"])
+  POST_AVAILABLE -->|yes| POST_COMMENT["Post exactly the returned final comment once; do not edit, expand, retry into duplicates, or mutate other tracker fields"]
+  POST_COMMENT --> POST_SUCCESS{"Post succeeded?"}
+  POST_SUCCESS -->|yes| POSTED_OUT(["Posted: return Mode=Posted, REVIEW_STATUS, posted comment, and validation summary"])
+  POST_SUCCESS -->|no| POST_FAIL(["Blocked or Ready to post: return post failure reason, exact unposted comment, and no retry side effect"])
+
+  class SOURCE_AVAILABLE,MUTATION_ONLY,POST_INTENT,POST_PRECHECK,ACCESS_GATE,TECH_CLAIMS,CLAIMS_SUPPORTED,SENSITIVE_REC,APPROVAL_AVAILABLE,QUALITY_PASS,FIX_COUNT,REVIEW_ROUTER,MODE_DECISION,DRAFT_MODE,POST_ALLOWED_GATE,POST_AVAILABLE,POST_SUCCESS decision;
+  class ROLE_BOUNDARY,CLASSIFY_EVIDENCE,REVIEW_POLICY,READINESS_CHECKS,VERIFY_CLAIMS,QUALITY_CHECK,FIELD_ROUTER,COORDINATOR_KEEP check;
+  class ASK_SOURCE,ASK_POSTING,ASK_OR_DEFER human;
+  class SNAPSHOT,DISPATCH,ASSEMBLE_COMMENT,REVIEW_RETURN,RETURN_REVIEWER_MODE,POST_COMMENT output;
+  class DRAFT_OUT,READY_TO_POST_OUT,POSTED_OUT success;
+  class DEFER_MUTATION,DEFERRED_OUT refine;
+  class BLOCKED_SOURCE,BLOCKED_POSTING,BLOCKED_ACCESS,ERROR_OUT,FAIL_OUT,BLOCKED_OUT,POST_FAIL stop;
 
   classDef guard fill:#fff3cd,stroke:#856404,color:#000;
   classDef check fill:#e7f1ff,stroke:#0b5ed7,color:#000;
   classDef decision fill:#f8f9fa,stroke:#495057,color:#000;
   classDef human fill:#f3e8ff,stroke:#6f42c1,color:#000;
   classDef output fill:#e8f5e9,stroke:#2e7d32,color:#000;
+  classDef success fill:#e8f5e9,stroke:#2e7d32,color:#000;
   classDef refine fill:#fff3cd,stroke:#856404,color:#000;
   classDef stop fill:#fdecea,stroke:#b02a37,color:#000;
-
-  class SOURCE_AVAILABLE,MUTATION_ONLY,POSTING_CLARITY,ACCESS_OK,TECH_CLAIMS,SENSITIVE_REC,APPROVAL_AVAILABLE,QUALITY_PASS,MODE_DECISION,DRAFT_READY_MODE,POST_ALLOWED_GATE,POST_AVAILABLE decision;
-  class REVIEWER_POLICY,READINESS_CHECKS,VERIFY_CLAIMS,QUALITY_CHECK,FIX_CYCLE check;
-  class ASK_SOURCE,ASK_POSTING,ASK_APPROVAL human;
-  class INTAKE,WRITE_INTENT,COLLECT_POINTERS,DISPATCH,CLASSIFY,ASSEMBLE_COMMENT,REVIEW_RETURN,COORDINATOR_KEEP,INCLUDE_REC,NEUTRALIZE_REC,POST_COMMENT guard;
-  class DRAFT_OUT,READY_TO_POST_OUT,POSTED_OUT,RETURN_REVIEWER_MODE output;
-  class DEFER_MUTATION refine;
-  class BLOCKED_SOURCE,BLOCKED_POSTING,BLOCKED_ACCESS stop;
 ```
 
-Readiness rule: the workflow completes only as `Draft`, `Ready to post`, `Posted`, `Blocked`, or `Deferred` after the reviewer returns a compact verdict and final comment, quality validation passes or safe failure handling is reported, and the coordinator returns only retained verdict fields plus the final comment. Posting requires explicit posting intent, available tooling, and `POST_ALLOWED=yes`; otherwise the coordinator must not mutate the tracker.
+Readiness rule: the workflow completes only as `Draft`, `Ready to post`, `Posted`, `Blocked`, or `Deferred`. Completion requires a compact reviewer verdict, explicit routing by `REVIEW`, `REVIEW_STATUS`, `Comment mode`, and `POST_ALLOWED`, and either a passing quality checklist or safe terminal handling for `FAIL`, `ERROR`, blocked access, or posting failure. Posting may happen only once, only for the exact reviewer-returned final comment, and only when `WRITE_MODE=post-comment`, posting tooling is available, and `POST_ALLOWED=yes`.

--- a/skills/refine-task/references/external-sources.md
+++ b/skills/refine-task/references/external-sources.md
@@ -20,8 +20,8 @@ network access is unavailable.
 
 | Need | Source |
 | ---- | ------ |
-| Jira issue and work item concepts | https://support.atlassian.com/jira-software-cloud/docs/what-are-issues/ |
-| Jira issue types | https://support.atlassian.com/jira-software-cloud/docs/what-are-issue-types/ |
+| Jira work item concepts | https://support.atlassian.com/jira-cloud-administration/docs/what-are-issues/ |
+| Jira work types and hierarchy | https://support.atlassian.com/jira-cloud-administration/docs/what-are-issue-types/ |
 | Atlassian epics | https://www.atlassian.com/agile/project-management/epics |
 | GitHub issue concepts | https://docs.github.com/en/issues/tracking-your-work-with-issues/about-issues |
 | GitHub tasklists and sub-issue style planning | https://docs.github.com/en/issues/tracking-your-work-with-issues/using-tasklists |
@@ -35,7 +35,7 @@ network access is unavailable.
 | Agile user stories overview | https://www.atlassian.com/agile/project-management/user-stories |
 | Acceptance criteria overview | https://www.atlassian.com/work-management/project-management/acceptance-criteria |
 | Gherkin syntax for testable scenarios | https://cucumber.io/docs/gherkin/reference/ |
-| Spikes as research work | https://www.mountaingoatsoftware.com/agile/user-stories/spikes |
+| Spikes as research work | https://www.mountaingoatsoftware.com/blog/spikes |
 
 ## Design Thinking And User Journey Context
 

--- a/skills/refine-task/references/refinement-checks.md
+++ b/skills/refine-task/references/refinement-checks.md
@@ -62,3 +62,18 @@ criteria.
 Classify every finding as source-backed fact, reviewer assumption, missing
 evidence, contradiction, or recommendation. Use missing evidence as evidence of a
 gap; do not fill gaps with plausible details.
+
+## Evidence Snapshot And Access
+
+Build a compact source snapshot before readiness checks. Include only source
+pointers such as item body, comments, subtasks, linked items, docs, code
+references, trusted external documentation, and timestamps when available.
+
+Classify missing evidence before deciding whether to block:
+
+| Classification | Handling |
+| -------------- | -------- |
+| Non-blocking gap | Continue review, mark the gap, and ask a refinement question. |
+| Unsupported technical claim | Verify against trusted docs or codebase evidence, then mark invalid claim, gap, spike need, or blocker based on impact. |
+| Contradiction | Name the conflicting evidence and ask the owner to resolve it. |
+| Missing access or source context | Return `REVIEW=BLOCKED` when meaningful review cannot proceed. |

--- a/skills/refine-task/references/review-quality-checklist.md
+++ b/skills/refine-task/references/review-quality-checklist.md
@@ -16,6 +16,8 @@
 | Output shape | The final comment contains all required sections from `comment-template.md`. |
 | Empty sections | Empty sections use `None` when omission could be ambiguous. |
 | External sources | Any fetched website is listed in the compact summary or evidence reviewed section. |
+| Return routing | The reviewer output includes `REVIEW`, `REVIEW_STATUS`, `POST_ALLOWED`, `Comment mode`, final comment, and validation summary so the coordinator can route deterministically. |
+| Posting side effects | Posting is attempted only once for the exact returned comment; post failure returns the exact unposted comment and failure reason without duplicate retry. |
 
 ## Fix Loop
 
@@ -33,3 +35,5 @@
 | Premature `Ready` | Change status to `Needs refinement`, `Needs split`, `Needs spike`, or `Blocked` and name the blocker. |
 | Missing output section | Add the section with `None` if no content exists. |
 | Technical claim unsupported | Fetch or cite trusted docs, or ask for owner clarification. |
+| Reviewer return ambiguous | Add the missing verdict field or validation note before returning. |
+| Posting outcome ambiguous | Return `Ready to post` or `Blocked` with the exact unposted comment and failure reason. |

--- a/skills/refine-task/references/reviewer-policy.md
+++ b/skills/refine-task/references/reviewer-policy.md
@@ -8,8 +8,10 @@
 
 The refinement review treats the Jira or GitHub item as source material. The
 reviewer may inspect available context, evaluate readiness, ask questions, and
-produce one refinement comment or draft. The reviewer's authority is advisory:
-recommendations are not permission to perform tracker changes.
+produce one refinement comment or draft. The coordinator may post that exact
+comment once when posting is explicitly requested, available, and allowed. The
+reviewer's authority is advisory: recommendations are not permission to perform
+tracker changes.
 
 ## Allowed Outcomes
 
@@ -25,7 +27,9 @@ recommendations are not permission to perform tracker changes.
 The workflow may produce one new refinement comment. It keeps existing tracker
 content unchanged: it does not edit title, body, fields, labels, status,
 assignee, milestone, sprint, existing comments, links, subtasks, child issues,
-or parent-child relationships.
+or parent-child relationships. If a post attempt fails, the coordinator returns
+the exact unposted comment and failure reason instead of retrying into duplicate
+side effects.
 
 Mutation examples that must be deferred: delete comments, close issues, merge or
 supersede items, edit labels, assign owners, move workflow status, create child
@@ -49,12 +53,16 @@ consider superseding this item?`
 
 1. Boundary: identify item type and write mode.
 2. Mutation gate: detect and defer tracker mutations beyond the refinement comment.
-3. Snapshot: list evidence reviewed and missing evidence.
+3. Snapshot: list evidence reviewed and classify missing evidence as
+   non-blocking gaps, unsupported claims, contradictions, or blocking missing
+   access/source context.
 4. Classification: identify item type and relevance state.
 5. Readiness checks: run the checklist that applies to the item.
 6. Synthesis: separate facts, assumptions, gaps, and recommendations.
 7. Recommendation gates: approve, neutralize, or defer sensitive recommendations.
 8. Comment: assemble the final comment or draft.
+9. Return routing: expose `REVIEW`, `REVIEW_STATUS`, `POST_ALLOWED`, `Comment mode`,
+   the final comment, and validation summary for coordinator routing.
 
 ## Readiness Rule
 

--- a/skills/refine-task/subagents/refinement-reviewer.md
+++ b/skills/refine-task/subagents/refinement-reviewer.md
@@ -39,9 +39,10 @@ coordinator.
 
 1. Load `REVIEWER_POLICY_PATH` before interpreting tracker mutations, write mode,
    gates, or lifecycle recommendations.
-2. Build a compact source snapshot from available context. If linked context or
-   evidence is missing, continue only when the missing data is non-blocking;
-   otherwise prepare a `Blocked` comment.
+2. Build a compact source snapshot from available context. Classify missing
+   evidence as a non-blocking gap, unsupported technical claim, contradiction, or
+   missing access/source context. Continue only when the missing data is
+   non-blocking; otherwise prepare a `Blocked` comment.
 3. Load `REFINEMENT_CHECKS_PATH` when running readiness checks. Record only check
    outcomes and evidence pointers, not full source text.
 4. Load `EXTERNAL_SOURCES_PATH` only when a source-backed refresher, current
@@ -81,6 +82,11 @@ Use `POST_ALLOWED=yes` only when `WRITE_MODE=post-comment`, the requested action
 is exactly posting a refinement comment, and no unresolved mutation or safety
 gate prevents posting. This subagent does not post; it reports whether posting is
 allowed for the coordinator.
+
+Return `REVIEW=PASS` only after the quality checklist passes. Return
+`REVIEW=FAIL` when review completed but the same quality issue remains after
+three targeted fix cycles. Return `REVIEW=ERROR` for unexpected runtime, tool,
+fetch, or parsing failures and set `POST_ALLOWED=no`.
 
 Use `Comment mode=Ready to post` for a refinement comment that is safe to post
 exactly as returned, `Comment mode=Draft` when the comment needs user review


### PR DESCRIPTION
## Summary

This PR strengthens the `refine-task` skill's reviewer-only workflow by introducing explicit `REVIEW` verdict routing (`PASS`, `BLOCKED`, `FAIL`, `ERROR`), evidence snapshot and access classification, and clearer posting gates. The coordinator now routes on structured subagent outcomes before choosing output mode, and the flow diagram reflects the updated orchestration.

## Key Changes

- Add `REVIEW` verdict exposure in the refinement-reviewer subagent and coordinator routing logic in `SKILL.md`
- Introduce evidence snapshot and access classification with blocking only when missing access prevents review
- Extend reviewer policy and quality checklist with posting and evidence gates
- Align `flow-diagram.md` with reviewer-only routing and validation terminals
- Refresh Jira and spike reference URLs in `external-sources.md`

## Impact

- Refinement reviews return clearer `Mode`, `Status`, `Comment`, and `Validation` fields with safer posting behavior (no auto-retry on post failure)
- Documentation-only change; no runtime migration required
- Solo-developer project: no reviewers requested

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to the `refine-task` skill contracts and diagrams; low risk aside from potentially changing how downstream users interpret/implement coordinator routing and posting behavior.
> 
> **Overview**
> Tightens the `refine-task` reviewer-only workflow by introducing an explicit `REVIEW` verdict (`PASS|BLOCKED|FAIL|ERROR`) and requiring the coordinator to route outputs based on `REVIEW`, `REVIEW_STATUS`, `Comment mode`, and `POST_ALLOWED`, including a new `Validation` field in the output contract.
> 
> Clarifies evidence handling by adding a compact source snapshot step and categorizing missing evidence (gaps vs unsupported claims vs contradictions vs blocking access/context), and strengthens posting safety rules (post at most once, exact comment only, and return the unposted comment plus failure reason on post errors). Also updates the mermaid flow diagram and refreshes a few external reference URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afe1899a823f7ead369a5abcc50192aa7709e483. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->