### PR TITLE
docs(pr-creator): add gate-based approval workflow and status contracts

### DIFF
--- a/skills/pr-creator/SKILL.md
+++ b/skills/pr-creator/SKILL.md
@@ -6,8 +6,9 @@ description: "Create review-ready pull requests from the current branch with a p
 # PR Creator
 
 You are a pull request creation orchestrator. Think, route, and ask for user
-approval; delegate repository inspection, diff analysis, drafting, metadata, and
-submission to focused subagents that return concise status blocks.
+approval; delegate repository inspection, platform adaptation, preflight checks,
+diff analysis, drafting, metadata, and submission to focused subagents that
+return concise status blocks.
 
 This skill is standalone. Bundled paths are relative to the file that contains
 them and stay inside this skill folder.
@@ -57,20 +58,31 @@ contract files, or external resources.
 ## Workflow
 
 1. Normalize inputs inline and ask the smallest missing-value question.
-2. Dispatch `repo-state-inspector`. If local changes exist, state that they are
-   outside the PR until committed; continue only on `REPO_STATE: PASS`.
-3. Dispatch `preflight-validator`. Ask before pushing; redispatch with
-   `PUSH_APPROVED=true` only after explicit user approval.
-4. Dispatch `diff-analyzer`. If the large or mixed-purpose gate trips, summarize
-   the issue and ask whether to proceed as one PR.
-5. Dispatch `pr-drafter`, then `review-metadata-suggester`. Resolve each
-   `NEEDS_*`, `INVALID_LABELS`, or `NEEDS_CHOICE` result with one focused user
-   question and redispatch the affected subagent.
-6. Load `./references/execution-contracts.md`, show the exact preview, and ask
-   for approval. Any edit to branch, state, title, body, reviewers, or labels
-   invalidates approval and re-runs the earliest affected phase.
-7. Dispatch `pr-submitter` only after the latest preview is approved. Return the
-   verified URL using the final success block.
+2. Dispatch `repo-state-inspector`. On `REPO_STATE: PASS`, record any
+   uncommitted-work boundary before preflight; local uncommitted changes stay
+   outside the PR until committed. Map `REPO_STATE: BLOCKED | ERROR` through the
+   failure envelope.
+3. Apply `./references/platform-adaptation.md` only after repo-state evidence
+   identifies the platform or adapter need, then dispatch `preflight-validator`.
+4. Route `PREFLIGHT: PUSH_REQUIRED` to `GATE_PUSH_APPROVAL`; redispatch with
+   `PUSH_APPROVED=true` only after explicit approval. Map `PREFLIGHT: AUTH`,
+   `BASE_BRANCH_MISSING`, `HEAD_BRANCH_UNPUSHED`, `BLOCKED`, and `ERROR` through
+   `./references/execution-contracts.md`.
+5. Dispatch `diff-analyzer`. Route `DIFF_ANALYSIS: LARGE_PR_CONFIRMATION_REQUIRED`
+   to `GATE_SCOPE_APPROVAL`; route `EMPTY_DIFF` and `ERROR` through the failure
+   envelope.
+6. Dispatch `pr-drafter`, then `review-metadata-suggester`. Resolve
+   `PR_DRAFT: NEEDS_CHOICE`, `REVIEW_METADATA: NEEDS_REVIEWER`, and
+   `REVIEW_METADATA: INVALID_LABELS` through focused bounded gates
+   (`GATE_DRAFT_CHOICE`, `GATE_REVIEWER`, `GATE_LABELS`) and redispatch the
+   affected subagent. There is no skip route around the required reviewer.
+7. Load `./references/execution-contracts.md`, show the exact preview, and route
+   approval through `GATE_PREVIEW_APPROVAL`. Any edit to branch, state, title,
+   body, reviewers, or labels invalidates approval and re-runs the earliest
+   affected phase.
+8. Freeze the approved preview fields, then dispatch `pr-submitter`. Return the
+   verified URL and submitted metadata on `PR_SUBMIT: PASS`; map `BLOCKED`,
+   `CREATE_ERROR`, `AUTH`, and `ERROR` through the failure envelope.
 
 For any non-pass status, load `./references/execution-contracts.md`, map the
 status to the failure envelope, and recover only the failing gate. Stop after
@@ -80,13 +92,16 @@ three non-converging fix cycles and ask the user for the final decision.
 
 - Use `origin/<target_branch>...origin/<current_branch>` as the trusted diff
   only after preflight confirms both remote refs are comparable.
-- Ask before pushing, before proceeding with a large or mixed-purpose PR, and
-  before creating the PR.
+- Ask at `GATE_PUSH_APPROVAL` before pushing, `GATE_SCOPE_APPROVAL` before
+  proceeding with a large or mixed-purpose PR, and `GATE_PREVIEW_APPROVAL` before
+  creating the PR.
 - Require at least one reviewer from user input, CODEOWNERS, or an explicit user
   answer before submission.
 - Use only labels that the hosting platform reports as existing.
 - Fetch external URLs for static guidance instead of copying that guidance into
   the prompt; preserve this skill's local contracts when sources disagree.
+- Recover only the failing gate or earliest affected phase. Stop after three
+  non-converging recovery cycles.
 
 ## Output Contract
 

--- a/skills/pr-creator/flow-diagram.md
+++ b/skills/pr-creator/flow-diagram.md
@@ -1,99 +1,148 @@
 # PR Creator Skill Flow
 
-The `pr-creator` orchestrator creates a review-ready PR or MR from the current branch by delegating repository inspection, preflight checks, diff analysis, drafting, metadata suggestion, and submission to subagents. It may normalize inputs, ask focused questions, recover only failing gates, and load execution contracts for preview, failure, and final output. It must stop for required human input, sensitive actions, metadata gaps, preview approval, failed checks, or three non-converging recovery cycles.
+The `skills/pr-creator` orchestrator creates a review-ready PR or MR from the
+current branch by delegating repository inspection, platform adaptation,
+preflight validation, diff analysis, drafting, review metadata, and submission to
+focused subagents. The orchestrator may normalize inputs, ask focused questions,
+recover only failing gates, and load local contracts. It must not push without
+`GATE_PUSH_APPROVAL` and must not create a PR or MR without
+`GATE_PREVIEW_APPROVAL`.
+
+## Contract References
+
+- `skills/pr-creator/SKILL.md`
+- `skills/pr-creator/subagents/repo-state-inspector.md`
+- `skills/pr-creator/subagents/preflight-validator.md`
+- `skills/pr-creator/subagents/diff-analyzer.md`
+- `skills/pr-creator/subagents/pr-drafter.md`
+- `skills/pr-creator/subagents/review-metadata-suggester.md`
+- `skills/pr-creator/subagents/pr-submitter.md`
+- `skills/pr-creator/references/execution-contracts.md`
+- `skills/pr-creator/references/platform-adaptation.md`
+- `skills/pr-creator/references/contracts/repo-state-inspector.md`
+- `skills/pr-creator/references/contracts/preflight-validator.md`
+- `skills/pr-creator/references/contracts/diff-analyzer.md`
+- `skills/pr-creator/references/contracts/pr-drafter.md`
+- `skills/pr-creator/references/contracts/review-metadata-suggester.md`
+- `skills/pr-creator/references/contracts/pr-submitter.md`
 
 ```mermaid
 flowchart TD
-  START([Start: create PR or MR from current branch]) --> INTAKE["Normalize inputs<br/>TARGET_BRANCH, PR_STATE, reviewers, overrides, labels, current branch, refs, auth, diff, CODEOWNERS, platform labels"]
-  INTAKE --> BOUNDARY["State authority boundary<br/>orchestrator delegates repo inspection, diff analysis, drafting, metadata validation, and submission"]
-  BOUNDARY --> TARGET_CHECK{TARGET_BRANCH provided?}
-  TARGET_CHECK -->|no| ASK_TARGET["Ask focused question:<br/>which target branch?"]
-  ASK_TARGET --> LOAD_FAILURE_OUTPUT["Load failure output contract<br/>return blocked or escalated status with one next step"]
-  TARGET_CHECK -->|yes| PLATFORM["Detect platform and adapt happy path<br/>GitHub default; use GitLab, Bitbucket, or unknown-platform contract when needed"]
-  PLATFORM --> PLATFORM_KNOWN{Exact platform behavior or syntax known?}
-  PLATFORM_KNOWN -->|no| FETCH_DOCS["Fetch optional external docs only for exact platform behavior"]
-  FETCH_DOCS --> DISPATCH_REPO["Dispatch repo-state-inspector<br/>collect current branch, remote refs, working-tree state, auth, and platform availability"]
-  PLATFORM_KNOWN -->|yes| DISPATCH_REPO
-  DISPATCH_REPO --> REPO_OK{Repository evidence usable?}
-  REPO_OK -->|no| FAILURE_REPO["Load failure output contract<br/>report failed or blocked status with one next step"]
-  FAILURE_REPO --> FAILED([Failed or blocked])
-  REPO_OK -->|yes| DISPATCH_PREFLIGHT["Dispatch preflight-validator<br/>confirm auth, comparable remote refs, branch publish status, and local-change boundary"]
-  DISPATCH_PREFLIGHT --> LOCAL_CHANGES{Uncommitted local changes present?}
-  LOCAL_CHANGES -->|yes| NOTE_LOCAL["Record boundary:<br/>local uncommitted changes stay outside PR until committed"]
-  NOTE_LOCAL --> PREFLIGHT_READY{Preflight gates pass?}
-  LOCAL_CHANGES -->|no| PREFLIGHT_READY
-  PREFLIGHT_READY -->|no| RECOVERABLE_PREFLIGHT{Failing gate recoverable?}
-  RECOVERABLE_PREFLIGHT -->|no| FAILURE_PREFLIGHT["Load failure output contract<br/>include failed gate and one clear next step"]
-  FAILURE_PREFLIGHT --> FAILED
-  RECOVERABLE_PREFLIGHT -->|yes| CYCLE_CHECK{Fewer than three non-converging fix cycles?}
-  CYCLE_CHECK -->|no| LOAD_FAILURE_OUTPUT
-  CYCLE_CHECK -->|yes| PUSH_NEEDED{Current branch must be pushed?}
-  PUSH_NEEDED -->|yes| PUSH_GATE["Human gate: approve pushing current branch<br/>target: remote branch<br/>reason: make compare ref available<br/>risk: publishes commits; reversible by deleting remote branch<br/>safer alternative: stop and let user push manually"]
-  PUSH_GATE -->|declined| LOAD_FAILURE_OUTPUT
-  PUSH_GATE -->|approved| RECOVER_PREFLIGHT["Recover only failing preflight gate<br/>record approval and rerun earliest affected phase"]
-  PUSH_NEEDED -->|no| RECOVER_PREFLIGHT
-  RECOVER_PREFLIGHT --> DISPATCH_REPO
-  PREFLIGHT_READY -->|yes| TRUSTED_DIFF["Use trusted compare diff<br/>origin/&lt;target_branch&gt;...origin/&lt;current_branch&gt; after refs are comparable"]
-  TRUSTED_DIFF --> DISPATCH_DIFF["Dispatch diff-analyzer<br/>assess size, purpose, risk, and change summary"]
-  DISPATCH_DIFF --> DIFF_SCOPE{Large or mixed-purpose PR?}
-  DIFF_SCOPE -->|yes| SCOPE_GATE["Human gate: approve proceeding with large or mixed-purpose PR<br/>target: current branch diff<br/>reason: review risk is elevated<br/>risk: lower review quality; safer alternative: split or stop"]
-  SCOPE_GATE -->|declined| LOAD_FAILURE_OUTPUT
-  SCOPE_GATE -->|approved| DRAFT["Dispatch pr-drafter<br/>produce preview-ready title and body using overrides when provided"]
-  DIFF_SCOPE -->|no| DRAFT
-  DRAFT --> META["Dispatch review-metadata-suggester<br/>suggest reviewers and labels from input, CODEOWNERS, platform reviewer data, and platform labels"]
-  META --> REVIEWER_CHECK{At least one reviewer available?}
-  REVIEWER_CHECK -->|no| ASK_REVIEWER["Ask user for at least one reviewer"]
-  ASK_REVIEWER --> LOAD_FAILURE_OUTPUT
-  REVIEWER_CHECK -->|yes| LABEL_CHECK{Labels valid for platform?}
-  LABEL_CHECK -->|no| RECOVER_LABELS{Recoverable label metadata issue?}
-  RECOVER_LABELS -->|no| FAILURE_LABELS["Load failure output contract<br/>include invalid labels and one next step"]
-  FAILURE_LABELS --> FAILED
-  RECOVER_LABELS -->|yes| META_CYCLE_CHECK{Fewer than three metadata recovery cycles?}
-  META_CYCLE_CHECK -->|no| LOAD_FAILURE_OUTPUT
-  META_CYCLE_CHECK -->|yes| RECOVER_META["Recover only metadata gate<br/>refresh platform labels or ask focused question"]
-  RECOVER_META --> META
-  LABEL_CHECK -->|yes| PREVIEW["Load preview output contract<br/>show exact branch, target branch, state, title, body, reviewers, labels, and platform"]
-  PREVIEW --> APPROVAL_GATE["Human gate: explicit preview approval<br/>target: PR or MR creation<br/>reason: submission is sensitive<br/>risk: public or team-visible artifact; safer alternative: revise preview or stop"]
-  APPROVAL_GATE -->|declined| PREVIEW_CHANGES{User requests field changes?}
-  PREVIEW_CHANGES -->|yes| EARLIEST_PHASE["Re-run earliest affected phase<br/>draft, metadata, diff, or preflight depending on changed field"]
-  EARLIEST_PHASE -->|title or body change| DRAFT
-  EARLIEST_PHASE -->|reviewer or label change| META
-  EARLIEST_PHASE -->|diff-affecting change| DISPATCH_DIFF
-  EARLIEST_PHASE -->|branch or preflight change| DISPATCH_PREFLIGHT
-  PREVIEW_CHANGES -->|no| LOAD_FAILURE_OUTPUT
-  APPROVAL_GATE -->|approved| FREEZE["Freeze approved preview fields<br/>do not change branch, state, title, body, reviewers, or labels without reapproval"]
-  FREEZE --> SUBMIT["Dispatch pr-submitter<br/>create PR or MR using approved preview only"]
-  SUBMIT --> VERIFY_URL{Platform returns verified PR or MR URL?}
-  VERIFY_URL -->|yes| FINAL["Load final output contract<br/>return verified URL and submitted metadata"]
-  FINAL --> SUCCESS([Success: verified PR or MR URL])
-  VERIFY_URL -->|no| FAILURE_SUBMIT["Load failure output contract<br/>return failed status with one clear next step"]
-  FAILURE_SUBMIT --> FAILED
-  LOAD_FAILURE_OUTPUT -->|missing target branch| TARGET_BLOCKED([Blocked: waiting for TARGET_BRANCH])
-  LOAD_FAILURE_OUTPUT -->|fix cycles exhausted| ESCALATE([Escalated: three non-converging fix cycles])
-  LOAD_FAILURE_OUTPUT -->|push declined| PUSH_BLOCKED([Blocked: user declined branch push])
-  LOAD_FAILURE_OUTPUT -->|scope declined| SCOPE_BLOCKED([Blocked: user declined large or mixed-purpose PR])
-  LOAD_FAILURE_OUTPUT -->|reviewer missing| REVIEWER_BLOCKED([Blocked: waiting for required reviewer])
-  LOAD_FAILURE_OUTPUT -->|preview not approved| PREVIEW_BLOCKED([Blocked: preview not approved])
+  START([Start]) --> INTAKE[Normalize inputs]
+  INTAKE --> REPO[Dispatch repo-state-inspector]
+  REPO --> REPO_STATUS{REPO_STATE}
 
+  REPO_STATUS -->|PASS| WORKTREE{Uncommitted work present}
+  REPO_STATUS -->|BLOCKED| BLOCKED_FAIL["PR_CREATE: BLOCKED"]
+  REPO_STATUS -->|ERROR| BLOCKED_FAIL
+
+  WORKTREE -->|yes| NOTE_LOCAL[Record uncommitted-work boundary]
+  WORKTREE -->|no| PLATFORM[Apply platform adaptation]
+  NOTE_LOCAL --> PLATFORM
+
+  PLATFORM --> PREFLIGHT[Dispatch preflight-validator]
+  PREFLIGHT --> PREFLIGHT_STATUS{PREFLIGHT}
+
+  PREFLIGHT_STATUS -->|PASS| DIFF[Dispatch diff-analyzer]
+  PREFLIGHT_STATUS -->|PUSH_REQUIRED| GATE_PUSH_APPROVAL{GATE_PUSH_APPROVAL}
+  PREFLIGHT_STATUS -->|AUTH| AUTH_FAIL["PR_CREATE: AUTH"]
+  PREFLIGHT_STATUS -->|BASE_BRANCH_MISSING| BASE_FAIL["PR_CREATE: BASE_BRANCH_MISSING"]
+  PREFLIGHT_STATUS -->|HEAD_BRANCH_UNPUSHED| HEAD_FAIL["PR_CREATE: HEAD_BRANCH_UNPUSHED"]
+  PREFLIGHT_STATUS -->|BLOCKED| BLOCKED_FAIL
+  PREFLIGHT_STATUS -->|ERROR| BLOCKED_FAIL
+
+  GATE_PUSH_APPROVAL -->|approved| PUSH_BRANCH[Push approved current branch]
+  GATE_PUSH_APPROVAL -->|declined| HEAD_FAIL
+  GATE_PUSH_APPROVAL -->|limit reached| BLOCKED_FAIL
+  PUSH_BRANCH --> PREFLIGHT
+
+  DIFF --> DIFF_STATUS{DIFF_ANALYSIS}
+  DIFF_STATUS -->|PASS| DRAFT[Dispatch pr-drafter]
+  DIFF_STATUS -->|LARGE_PR_CONFIRMATION_REQUIRED| GATE_SCOPE_APPROVAL{GATE_SCOPE_APPROVAL}
+  DIFF_STATUS -->|EMPTY_DIFF| EMPTY_FAIL["PR_CREATE: EMPTY_DIFF"]
+  DIFF_STATUS -->|ERROR| BLOCKED_FAIL
+
+  GATE_SCOPE_APPROVAL -->|approved| DRAFT
+  GATE_SCOPE_APPROVAL -->|declined| CANCEL_FAIL["PR_CREATE: CANCELLED"]
+  GATE_SCOPE_APPROVAL -->|limit reached| CANCEL_FAIL
+
+  DRAFT --> DRAFT_STATUS{PR_DRAFT}
+  DRAFT_STATUS -->|PASS| META[Dispatch review-metadata-suggester]
+  DRAFT_STATUS -->|NEEDS_CHOICE| GATE_DRAFT_CHOICE{GATE_DRAFT_CHOICE}
+  DRAFT_STATUS -->|ERROR| BLOCKED_FAIL
+
+  GATE_DRAFT_CHOICE -->|choice provided| DRAFT
+  GATE_DRAFT_CHOICE -->|cancelled| CANCEL_FAIL
+  GATE_DRAFT_CHOICE -->|limit reached| BLOCKED_FAIL
+
+  META --> META_STATUS{REVIEW_METADATA}
+  META_STATUS -->|PASS| PREVIEW[Load preview output contract]
+  META_STATUS -->|NEEDS_REVIEWER| GATE_REVIEWER{GATE_REVIEWER}
+  META_STATUS -->|INVALID_LABELS| GATE_LABELS{GATE_LABELS}
+  META_STATUS -->|AUTH| AUTH_FAIL
+  META_STATUS -->|ERROR| BLOCKED_FAIL
+
+  GATE_REVIEWER -->|reviewer provided| META
+  GATE_REVIEWER -->|cancelled| CANCEL_FAIL
+  GATE_REVIEWER -->|limit reached| BLOCKED_FAIL
+
+  GATE_LABELS -->|labels corrected| META
+  GATE_LABELS -->|labels removed| META
+  GATE_LABELS -->|cancelled| CANCEL_FAIL
+  GATE_LABELS -->|limit reached| BLOCKED_FAIL
+
+  PREVIEW --> GATE_PREVIEW_APPROVAL{GATE_PREVIEW_APPROVAL}
+  GATE_PREVIEW_APPROVAL -->|approved| FREEZE[Freeze approved preview fields]
+  GATE_PREVIEW_APPROVAL -->|revise title or body| DRAFT
+  GATE_PREVIEW_APPROVAL -->|revise reviewers or labels| META
+  GATE_PREVIEW_APPROVAL -->|revise branch or preflight| PREFLIGHT
+  GATE_PREVIEW_APPROVAL -->|declined| CANCEL_FAIL
+
+  FREEZE --> SUBMIT[Dispatch pr-submitter]
+  SUBMIT --> SUBMIT_STATUS{PR_SUBMIT}
+  SUBMIT_STATUS -->|PASS| SUCCESS([Success: verified PR or MR URL])
+  SUBMIT_STATUS -->|BLOCKED| BLOCKED_FAIL
+  SUBMIT_STATUS -->|CREATE_ERROR| CREATE_FAIL["PR_CREATE: CREATE_ERROR"]
+  SUBMIT_STATUS -->|AUTH| AUTH_FAIL
+  SUBMIT_STATUS -->|ERROR| CREATE_FAIL
+
+  classDef subagent fill:#e7f1ff,stroke:#0b5ed7,color:#000;
+  classDef gate fill:#f3e8ff,stroke:#6f42c1,color:#000;
   classDef guard fill:#fff3cd,stroke:#856404,color:#000;
-  classDef check fill:#e7f1ff,stroke:#0b5ed7,color:#000;
-  classDef decision fill:#f8f9fa,stroke:#495057,color:#000;
-  classDef human fill:#f3e8ff,stroke:#6f42c1,color:#000;
-  classDef output fill:#e8f5e9,stroke:#2e7d32,color:#000;
-  classDef success fill:#e8f5e9,stroke:#2e7d32,color:#000;
-  classDef refine fill:#fff3cd,stroke:#856404,color:#000;
   classDef stop fill:#fdecea,stroke:#b02a37,color:#000;
+  classDef success fill:#e8f5e9,stroke:#2e7d32,color:#000;
 
-  class TARGET_CHECK,PLATFORM_KNOWN,REPO_OK,LOCAL_CHANGES,PREFLIGHT_READY,RECOVERABLE_PREFLIGHT,CYCLE_CHECK,PUSH_NEEDED,DIFF_SCOPE,REVIEWER_CHECK,LABEL_CHECK,RECOVER_LABELS,META_CYCLE_CHECK,PREVIEW_CHANGES,VERIFY_URL decision;
-  class DISPATCH_REPO,DISPATCH_PREFLIGHT,TRUSTED_DIFF,DISPATCH_DIFF,DRAFT,META,RECOVER_PREFLIGHT,RECOVER_META,SUBMIT check;
-  class EARLIEST_PHASE refine;
-  class PUSH_GATE,SCOPE_GATE,APPROVAL_GATE human;
-  class LOAD_FAILURE_OUTPUT,PREVIEW,FINAL output;
+  class REPO,PREFLIGHT,DIFF,DRAFT,META,SUBMIT subagent;
+  class GATE_PUSH_APPROVAL,GATE_SCOPE_APPROVAL,GATE_DRAFT_CHOICE,GATE_REVIEWER,GATE_LABELS,GATE_PREVIEW_APPROVAL gate;
+  class INTAKE,WORKTREE,NOTE_LOCAL,PLATFORM,PREVIEW,FREEZE,PUSH_BRANCH guard;
+  class AUTH_FAIL,BASE_FAIL,HEAD_FAIL,EMPTY_FAIL,BLOCKED_FAIL,CANCEL_FAIL,CREATE_FAIL stop;
   class SUCCESS success;
-  class ASK_TARGET,NOTE_LOCAL,FETCH_DOCS,FREEZE guard;
-  class FAILURE_REPO,FAILURE_PREFLIGHT,FAILURE_LABELS,FAILURE_SUBMIT,TARGET_BLOCKED,FAILED,ESCALATE,PUSH_BLOCKED,SCOPE_BLOCKED,REVIEWER_BLOCKED,PREVIEW_BLOCKED stop;
 ```
 
-Readiness rule: the orchestrator may dispatch `pr-submitter` only after repository checks, comparable remote refs, diff analysis, draft preview, reviewer and label validation, sensitive-action gates, and explicit preview approval all pass.
+## Status Contracts
 
-Failure envelope rule: every blocked, failed, or escalated terminal state must return a single status, the gate that stopped progress, evidence used, and one clear next step.
+- `REPO_STATE: PASS | BLOCKED | ERROR`
+- `PREFLIGHT: PASS | PUSH_REQUIRED | AUTH | BASE_BRANCH_MISSING | HEAD_BRANCH_UNPUSHED | BLOCKED | ERROR`
+- `DIFF_ANALYSIS: PASS | LARGE_PR_CONFIRMATION_REQUIRED | EMPTY_DIFF | ERROR`
+- `PR_DRAFT: PASS | NEEDS_CHOICE | ERROR`
+- `REVIEW_METADATA: PASS | NEEDS_REVIEWER | INVALID_LABELS | AUTH | ERROR`
+- `PR_SUBMIT: PASS | BLOCKED | CREATE_ERROR | AUTH | ERROR`
+
+## Terminal Rules
+
+- `PR_CREATE: AUTH` returns the gate that failed, evidence used, and one next
+  step to authenticate or refresh access.
+- `PR_CREATE: BASE_BRANCH_MISSING` returns the missing target branch evidence and
+  one next step to choose an existing target branch.
+- `PR_CREATE: HEAD_BRANCH_UNPUSHED` returns the source branch evidence and one
+  next step to push manually or approve the orchestrator to push.
+- `PR_CREATE: EMPTY_DIFF` returns the compare range evidence and one next step to
+  add commits or choose a different branch pair.
+- `PR_CREATE: BLOCKED` returns the blocked subagent status, evidence used, and
+  one next step to resolve the blocker.
+- `PR_CREATE: CANCELLED` returns the declined gate and one next step to rerun
+  after approval is available.
+- `PR_CREATE: CREATE_ERROR` returns the create or verification failure and one
+  next step to correct and retry.
+- Success returns the verified PR or MR URL plus frozen submitted metadata from
+  `PR_SUBMIT: PASS`.

--- a/skills/pr-creator/references/execution-contracts.md
+++ b/skills/pr-creator/references/execution-contracts.md
@@ -19,21 +19,21 @@ Next step: <one clear action>
 | ------------- | ------------- |
 | `PREFLIGHT: AUTH`, `PR_SUBMIT: AUTH`, `REVIEW_METADATA: AUTH` | `AUTH` |
 | `PREFLIGHT: BASE_BRANCH_MISSING` | `BASE_BRANCH_MISSING` |
-| `PREFLIGHT: HEAD_BRANCH_UNPUSHED` or declined push | `HEAD_BRANCH_UNPUSHED` |
+| `PREFLIGHT: HEAD_BRANCH_UNPUSHED` or declined `GATE_PUSH_APPROVAL` | `HEAD_BRANCH_UNPUSHED` |
 | `DIFF_ANALYSIS: EMPTY_DIFF` | `EMPTY_DIFF` |
-| `REPO_STATE: BLOCKED`, `PREFLIGHT: BLOCKED`, `PR_SUBMIT: BLOCKED` | `BLOCKED` |
-| User declines large-PR or create confirmation | `CANCELLED` |
-| `PR_SUBMIT: CREATE_ERROR` | `CREATE_ERROR` |
-| Any subagent `ERROR` | `BLOCKED` with the subagent reason |
+| `REPO_STATE: BLOCKED`, `PREFLIGHT: BLOCKED`, `PR_SUBMIT: BLOCKED`, unresolved `REVIEW_METADATA: INVALID_LABELS`, bounded `GATE_PUSH_APPROVAL`, `GATE_DRAFT_CHOICE`, `GATE_REVIEWER`, or `GATE_LABELS` exhaustion | `BLOCKED` |
+| User declines `GATE_SCOPE_APPROVAL`, `GATE_DRAFT_CHOICE`, `GATE_REVIEWER`, `GATE_LABELS`, or `GATE_PREVIEW_APPROVAL`; or `GATE_SCOPE_APPROVAL` reaches its limit | `CANCELLED` |
+| `PR_SUBMIT: CREATE_ERROR` or `PR_SUBMIT: ERROR` | `CREATE_ERROR` |
+| Any non-submit subagent `ERROR` | `BLOCKED` with the subagent reason |
 
-Recover by re-running only the earliest affected phase. After three
-non-converging preview or validation cycles, ask the user for exact final values
-or permission to stop.
+Recover by re-running only the failing gate or earliest affected phase. After
+three non-converging preview, draft-choice, reviewer, label, or validation
+cycles, ask the user for exact final values or permission to stop.
 
 ## Preview Template
 
-Show this before creating anything. Any edit to title, body, reviewer, label,
-branch, or state invalidates approval.
+Show this before `GATE_PREVIEW_APPROVAL`. Any edit to title, body, reviewer,
+label, branch, or state invalidates approval.
 
 ```text
 PR Preview
@@ -58,7 +58,7 @@ Base: <target_branch>
 Head: <current_branch>
 Title: <title>
 State: <draft|ready>
-Reviewers: <reviewer list or none>
+Reviewers: <reviewer list>
 Labels: <label list or none>
 
 Description:

--- a/skills/pr-creator/references/platform-adaptation.md
+++ b/skills/pr-creator/references/platform-adaptation.md
@@ -1,9 +1,9 @@
 # Platform Adaptation
 
-> Load this file when the remote is GitLab, Bitbucket, unknown, or when GitHub
-> tooling cannot authenticate against a GitHub-compatible repository. Fetch exact
-> command or API syntax from `./external-resources.md` only for the
-> active platform.
+> Load this file after `repo-state-inspector` reports the platform or adapter
+> need, when the remote is GitLab, Bitbucket, unknown, or when GitHub tooling
+> cannot authenticate against a GitHub-compatible repository. Fetch exact command
+> or API syntax from `./external-resources.md` only for the active platform.
 
 Non-GitHub flows keep the same safety gates: validate auth, confirm remote refs,
 compare the approved branch range, preview exact fields, wait for user approval,


### PR DESCRIPTION
## Summary

This updates the pr-creator skill to route orchestration through explicit approval gates (push, scope, preview) and to name terminal status contracts for failures and recovery. The flow diagram is rewritten to show gate-routed subagent dispatch instead of a monolithic flowchart.

## Key Changes

- Defer platform-adaptation loading until repo-state identifies the platform
- Name gate-based failure and preview contracts with bounded recovery rules
- Route orchestrator steps through GATE_PUSH_APPROVAL, GATE_SCOPE_APPROVAL, and GATE_PREVIEW_APPROVAL
- Rewrite flow diagram with gate status contracts, subagent dispatch, and terminal status rules

## Impact

- PR creation workflow is clearer about when user approval is required
- Documentation-only change; no runtime migration or test changes needed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates that clarify orchestration and error/approval routing without changing runtime behavior.
> 
> **Overview**
> Refactors the `pr-creator` skill docs to route PR creation through explicit, named approval gates (push, scope, draft choice, reviewer/labels, and preview) and to require freezing preview fields before submission.
> 
> Rewrites the flow diagram and execution contracts to define standardized status contracts (`REPO_STATE`, `PREFLIGHT`, `DIFF_ANALYSIS`, `PR_DRAFT`, `REVIEW_METADATA`, `PR_SUBMIT`), tighten failure-envelope mappings (including gate exhaustion/declines), and defer loading `platform-adaptation.md` until `repo-state-inspector` indicates it’s needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5511e3029f5864d0daf6f80700c82f4b51502b2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->