### PR TITLE
docs(review-software-engineer-cv): add flow diagram overview

### DIFF
--- a/skills/review-software-engineer-cv/flow-diagram.md
+++ b/skills/review-software-engineer-cv/flow-diagram.md
@@ -73,3 +73,5 @@ flowchart TD
   class FINAL,PARTIAL_FINAL success;
   class BLOCKED_MISSING,BLOCKED_EVIDENCE,BLOCKED_RISK,BLOCKED_VERIFY,PHASE_ERROR stop;
 ```
+
+Completion rule: finish with a final reviewed report, a blocked missing-source request, a partial reviewed report with labeled limitations, a phase error, or a blocker after three failed targeted fix cycles.

--- a/skills/review-software-engineer-cv/flow-diagram.md
+++ b/skills/review-software-engineer-cv/flow-diagram.md
@@ -1,3 +1,58 @@
 # Review Software Engineer CV
 
 This workflow reviews a software engineer CV against a job posting. The agent may coordinate intake, role-fit mapping, truthful tailoring, validation, and a user-facing report, but it must not invent candidate facts, inflate seniority, fabricate metrics, or treat external resume guidance as candidate evidence. Primary evidence is the provided `CV`, `APPLICANT_CONTEXT`, and `JOB_POSTING`; optional fetched sources are background only.
+
+```mermaid
+flowchart TD
+  START([Start: review software engineer CV]) --> NORMALIZE[Normalize OUTPUT_MODE or default to review]
+  NORMALIZE --> CHECK_REQUIRED{Readable CV and JOB_POSTING provided?}
+
+  CHECK_REQUIRED -->|no| ASK_REQUIRED[Ask user for missing or unreadable required source]
+  ASK_REQUIRED --> BLOCKED_MISSING([Blocked: pending required source])
+
+  CHECK_REQUIRED -->|yes| INTAKE[Dispatch source-intake-analyst]
+  INTAKE -->|phase error| PHASE_ERROR([Error: phase failed])
+  INTAKE --> SOURCE_OK{Enough primary evidence remains?}
+  SOURCE_OK -->|no| BLOCKED_EVIDENCE([Blocked: insufficient evidence])
+  SOURCE_OK -->|yes| LIMITS[Record limitations for partial, inaccessible, or ambiguous sources]
+
+  LIMITS --> MAP[Dispatch role-fit-mapper]
+  MAP -->|phase error| PHASE_ERROR
+  MAP --> TAILOR[Dispatch cv-tailoring-editor]
+  TAILOR -->|phase error| PHASE_ERROR
+  TAILOR --> LABEL[Label rewrites and recommendations by evidence support]
+  LABEL --> UNSUPPORTED{Unsupported claims, metrics, seniority, or domain depth?}
+
+  UNSUPPORTED -->|yes| QUESTIONS[Ask user verification questions for unsupported claims]
+  QUESTIONS --> USER_VERIFY{User verifies candidate claim?}
+  USER_VERIFY -->|confirmed| INCLUDE_CONFIRMED[Include confirmed claim with evidence label]
+  USER_VERIFY -->|declined or unverified| EXCLUDE_UNVERIFIED[Exclude claim or keep it as a question]
+  USER_VERIFY -->|unresolved or handoff needed| BLOCKED_VERIFY([Blocked: unresolved verification handoff])
+  INCLUDE_CONFIRMED --> REVIEW
+  EXCLUDE_UNVERIFIED --> REVIEW
+
+  UNSUPPORTED -->|no| REVIEW[Dispatch cv-reviewer with compact summaries and verdicts]
+  REVIEW -->|phase error| PHASE_ERROR
+  REVIEW --> PASSES{Quality checklist passes?}
+  PASSES -->|yes| LIMITATION_STATE{Limitations require partial report?}
+  PASSES -->|validation error| PHASE_ERROR
+  PASSES -->|no| FIX_CYCLES{Targeted fix cycles under 3?}
+
+  FIX_CYCLES -->|yes| RERUN[Run targeted editor or reviewer fix]
+  RERUN --> LABEL
+  FIX_CYCLES -->|no| BLOCKED_RISK([Blocked: unresolved integrity risk])
+
+  LIMITATION_STATE -->|yes| PARTIAL_REPORT[Return partial reviewed report with labeled limitations]
+  LIMITATION_STATE -->|no| MODE{OUTPUT_MODE}
+
+  MODE -->|review| REPORT_REVIEW[Return reviewed report]
+  MODE -->|rewrite| REPORT_REWRITE[Return supported rewrites with evidence labels]
+  MODE -->|checklist| REPORT_CHECKLIST[Return checklist and prioritized edits]
+  MODE -->|questions-only| REPORT_QUESTIONS[Return verification questions only]
+
+  REPORT_REVIEW --> FINAL([Complete: final reviewed report])
+  REPORT_REWRITE --> FINAL
+  REPORT_CHECKLIST --> FINAL
+  REPORT_QUESTIONS --> FINAL
+  PARTIAL_REPORT --> PARTIAL_FINAL([Complete: partial reviewed report with limitations])
+```

--- a/skills/review-software-engineer-cv/flow-diagram.md
+++ b/skills/review-software-engineer-cv/flow-diagram.md
@@ -55,4 +55,21 @@ flowchart TD
   REPORT_CHECKLIST --> FINAL
   REPORT_QUESTIONS --> FINAL
   PARTIAL_REPORT --> PARTIAL_FINAL([Complete: partial reviewed report with limitations])
+
+  classDef guard fill:#fff3cd,stroke:#856404,color:#000;
+  classDef check fill:#e7f1ff,stroke:#0b5ed7,color:#000;
+  classDef decision fill:#f8f9fa,stroke:#495057,color:#000;
+  classDef human fill:#f3e8ff,stroke:#6f42c1,color:#000;
+  classDef output fill:#e8f5e9,stroke:#2e7d32,color:#000;
+  classDef success fill:#e8f5e9,stroke:#2e7d32,color:#000;
+  classDef refine fill:#fff3cd,stroke:#856404,color:#000;
+  classDef stop fill:#fdecea,stroke:#b02a37,color:#000;
+
+  class CHECK_REQUIRED,SOURCE_OK,UNSUPPORTED,USER_VERIFY,PASSES,FIX_CYCLES,LIMITATION_STATE,MODE decision;
+  class NORMALIZE,INTAKE,LIMITS,MAP,TAILOR,LABEL,REVIEW,RERUN,INCLUDE_CONFIRMED,EXCLUDE_UNVERIFIED check;
+  class ASK_REQUIRED,QUESTIONS guard;
+  class USER_VERIFY human;
+  class REPORT_REVIEW,REPORT_REWRITE,REPORT_CHECKLIST,REPORT_QUESTIONS,PARTIAL_REPORT output;
+  class FINAL,PARTIAL_FINAL success;
+  class BLOCKED_MISSING,BLOCKED_EVIDENCE,BLOCKED_RISK,BLOCKED_VERIFY,PHASE_ERROR stop;
 ```

--- a/skills/review-software-engineer-cv/flow-diagram.md
+++ b/skills/review-software-engineer-cv/flow-diagram.md
@@ -75,3 +75,5 @@ flowchart TD
 ```
 
 Completion rule: finish with a final reviewed report, a blocked missing-source request, a partial reviewed report with labeled limitations, a phase error, or a blocker after three failed targeted fix cycles.
+
+Sensitive-action rule: any recommendation or rewrite that would publish a candidate claim must be supported by the CV, applicant context, or job posting; otherwise it must be confirmed by the user, excluded, kept as a verification question, or handed off as unresolved rather than asserted.

--- a/skills/review-software-engineer-cv/flow-diagram.md
+++ b/skills/review-software-engineer-cv/flow-diagram.md
@@ -1,0 +1,3 @@
+# Review Software Engineer CV
+
+This workflow reviews a software engineer CV against a job posting. The agent may coordinate intake, role-fit mapping, truthful tailoring, validation, and a user-facing report, but it must not invent candidate facts, inflate seniority, fabricate metrics, or treat external resume guidance as candidate evidence. Primary evidence is the provided `CV`, `APPLICANT_CONTEXT`, and `JOB_POSTING`; optional fetched sources are background only.


### PR DESCRIPTION
## Summary

Adds a Mermaid flow diagram for the review-software-engineer-cv skill so the CV review orchestration — intake, role-fit mapping, tailoring, verification gates, and output modes — is visible at a glance.

## Key Changes

- New `flow-diagram.md` with a full orchestration flowchart including guard gates, human verification steps, and terminal outcomes
- Node styling classes for guard, decision, human, output, success, and stop states
- Completion rule and sensitive-action rule documenting evidence requirements for candidate claims

## Impact

- Documentation-only; no runtime or skill behavior changes
- Aligns with flow-diagram patterns used by other skills in this repo

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change adding a Mermaid flowchart; no runtime logic or data/auth pathways are modified.
> 
> **Overview**
> Adds `skills/review-software-engineer-cv/flow-diagram.md`, a Mermaid flowchart documenting the CV-review orchestration from required-input checks through intake/mapping/tailoring/review, including verification gates for unsupported claims and terminal outcomes.
> 
> Also documents completion and *sensitive-action* evidence rules and applies diagram styling classes for decision/guard/human/output/stop states.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5227ff397a119fe3f97d7418c2d204846ce18a8d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->