### PR TITLE
docs(recency-guard): add bounded repair gates and terminal states

### DIFF
--- a/skills/recency-guard/SKILL.md
+++ b/skills/recency-guard/SKILL.md
@@ -39,7 +39,8 @@ is not supplied, use the runtime's current date.
 | Recency audit | `recency-checker` | `RECENCY_CHECK` report |
 | Claim stress-test | `claim-verifier` | `CLAIM_REVIEW` report |
 | Completeness | Inline | Missing requested material fixed or acknowledged |
-| Clarity | Inline | Final user-visible answer |
+| Final wording | Inline | `NEW_CLAIM_CHECK` and `LIMIT_GATE` resolved |
+| Clarity | Inline | `READY`, `BLOCKED_TOOLS_MISSING`, `MATERIAL_UNCERTAINTY`, `NEEDS_REPAIR`, or `OUT_OF_SCOPE` |
 
 Run phases sequentially. Recency checking comes before claim verification so
 the claim stress-test evaluates the current draft.
@@ -82,19 +83,31 @@ uncertainty only when it materially affects the answer.
 2. Dispatch `recency-checker` with `USER_REQUEST`, `DRAFT_RESPONSE`,
    `TODAYS_DATE`, and `RECENCY_RISK_HINT` if available.
 3. Apply only the recency report's flagged edits. On `FAIL`, load
-   `./references/repair-and-integration.md` and rerun only within its repair
-   cap.
+   `./references/repair-and-integration.md` and use `RECENCY_REPAIR` to allow
+   at most 2 targeted reruns. On `ERROR`, use `RECENCY_ERROR` to retry once.
+   On `TOOLS_MISSING`, set a tools-missing limitation flag and keep only
+   supportable freshness claims.
 4. Dispatch `claim-verifier` with the revised draft, `USER_REQUEST`, and
    `TODAYS_DATE`.
-5. Apply only the claim review's required edits. On `FAIL`, rerun only within
-   the same repair cap.
+5. Apply only the claim review's required edits. On `FAIL`, use
+   `CLAIM_REPAIR` to allow at most 2 targeted reruns. On `ERROR`, use
+   `CLAIM_ERROR` to retry once. On `TOOLS_MISSING`, keep the limitation flag
+   visible and qualify evidence strength.
 6. Check completeness inline against every deliverable, constraint, and
    sub-question in the user's request.
 7. Apply confidence-to-wording rules from
    `./references/repair-and-integration.md`, put the bottom line early, and
    keep qualifiers proportional to remaining uncertainty.
-8. If the final pass adds a new time-sensitive or decision-shaping
-   claim, rerun the relevant subagent before finalizing.
+8. Run `NEW_CLAIM_CHECK`. If final wording or completeness repair adds a new
+   time-sensitive claim, rerun `recency-checker`; if it adds a new
+   decision-shaping claim, rerun `claim-verifier`; if it adds both, rerun the
+   relevant checks one at a time before finalizing.
+9. Run `LIMIT_GATE`. If tools are missing and material, return
+   `BLOCKED_TOOLS_MISSING`; if uncertainty is material, return
+   `MATERIAL_UNCERTAINTY`; if neither applies, return `READY`. If a repair cap
+   is reached, return `NEEDS_REPAIR`. If the request requires external
+   mutation or a high-impact action, return `OUT_OF_SCOPE` and route it to a
+   separate approved workflow.
 
 ## Output Contract
 
@@ -102,12 +115,17 @@ Return the user-visible answer, not a verification report. Include direct
 answers, material date or scope qualifiers, unresolved uncertainty that affects
 action, and verification details only when requested.
 
+Terminal states are `READY`, `BLOCKED_TOOLS_MISSING`,
+`MATERIAL_UNCERTAINTY`, `NEEDS_REPAIR`, and `OUT_OF_SCOPE`.
+
 ## Validation
 
 - `SKILL.md` is the routing layer; detailed rules stay in one-hop references.
 - Subagent files are read only for the current dispatch.
 - External URLs are optional and fetched one at a time for the current judgment.
 - Each repair cycle changes only flagged claims and stops at the repair cap.
+- `NEW_CLAIM_CHECK` runs before terminal output.
+- `LIMIT_GATE` preserves material tools-missing and uncertainty flags.
 
 ## Example
 

--- a/skills/recency-guard/flow-diagram.md
+++ b/skills/recency-guard/flow-diagram.md
@@ -1,82 +1,84 @@
 # Recency Guard
 
-Recency Guard is a read-only response-validation workflow for answers that depend on current external facts. It may draft or inspect an answer, identify high-risk or time-sensitive claims, dispatch focused verification subagents one at a time, apply only flagged edits within repair caps, and produce the final user-visible answer. Current external facts require evidence from official, canonical, or otherwise authoritative sources; no external mutations, posting, purchasing, deploying, policy changes, or irreversible actions are inside this flow.
+Recency Guard is a read-only response-validation orchestrator for answers that depend on current external facts. It prepares or inspects a draft response, identifies high-risk and time-sensitive claims, dispatches `./subagents/recency-checker.md` and `./subagents/claim-verifier.md` one at a time, applies only flagged repairs within bounded caps, and produces the final user-visible answer. Current external facts require evidence from official, canonical, or otherwise authoritative sources, guided by `./references/evidence-policy.md`, `./references/claim-extraction-playbook.md`, `./references/repair-and-integration.md`, `./references/output-templates.md`, and `./references/external-sources.md`. External mutations, posting, purchasing, deploying, policy changes, and irreversible actions are outside this flow and must be routed to a separate approved workflow.
 
 ```mermaid
 flowchart TD
-  START([Start: USER_REQUEST received]) --> INPUTS[Collect inputs: USER_REQUEST, optional DRAFT_RESPONSE, optional TODAYS_DATE, optional RECENCY_RISK_HINT]
+  START([Start: USER_REQUEST received]) --> INPUTS["Collect inputs: USER_REQUEST, optional DRAFT_RESPONSE, optional TODAYS_DATE, optional RECENCY_RISK_HINT"]
   INPUTS --> DATE{TODAYS_DATE present?}
   DATE -->|yes| DRAFT_CHECK{DRAFT_RESPONSE present?}
   DATE -->|no| SET_DATE[Use runtime current date]
   SET_DATE --> DRAFT_CHECK
 
-  DRAFT_CHECK -->|yes| SCOPE[State read-only boundary and freshness scope]
+  DRAFT_CHECK -->|yes| BOUNDARY[State read-only boundary, evidence standard, and freshness scope]
   DRAFT_CHECK -->|no| DRAFT[Draft concise answer first]
-  DRAFT --> SCOPE
+  DRAFT --> BOUNDARY
 
-  SCOPE --> MUTATION{External mutation requested?}
-  MUTATION -->|yes| OUT_OF_SCOPE([Outside this flow: route to separate approved workflow])
+  BOUNDARY --> MUTATION{External mutation or high-impact action requested?}
+  MUTATION -->|yes| OUT_OF_SCOPE([OUT_OF_SCOPE: route to separate approved workflow])
   MUTATION -->|no| RISK[Identify high-risk and time-sensitive claims]
-  RISK --> RECENCY[Dispatch recency-checker with focused read-only verification request]
-  RECENCY --> RECENCY_STATUS{RECENCY_CHECK status?}
 
-  RECENCY_STATUS -->|PASS| CLAIM_SELECT[Select up to 3 decision-shaping claims]
-  RECENCY_STATUS -->|FAIL| RECENCY_FIX[Apply only recency-checker flagged edits]
-  RECENCY_STATUS -->|TOOLS_MISSING| RECENCY_LIMIT[Keep only supportable claims and qualify freshness limits]
-  RECENCY_STATUS -->|ERROR| RECENCY_ERROR{Repeated error or repair cap hit?}
+  RISK --> RECENCY_INIT[Dispatch ./subagents/recency-checker.md initial review]
+  RECENCY_INIT --> RECENCY_STATUS{RECENCY_CHECK status?}
 
-  RECENCY_FIX --> RECENCY_CAP{Repair cap reached?}
-  RECENCY_CAP -->|no| RECENCY
-  RECENCY_CAP -->|yes| CAP_STOP([Stop at repair cap: conservative answer with uncertainty])
+  RECENCY_STATUS -->|PASS| CLAIM_SELECT[Select decision-shaping claims for claim review]
+  RECENCY_STATUS -->|FAIL| RECENCY_REPAIR{Recency FAIL reruns used < 2?}
+  RECENCY_REPAIR -->|yes| RECENCY_FIX[Apply only recency-checker flagged edits]
+  RECENCY_FIX --> RECENCY_RERUN[Targeted rerun of ./subagents/recency-checker.md]
+  RECENCY_RERUN --> RECENCY_STATUS
+  RECENCY_REPAIR -->|no| NEEDS_REPAIR([NEEDS_REPAIR: recency repair cap reached])
 
-  RECENCY_ERROR -->|no| RECENCY
-  RECENCY_ERROR -->|yes| UNCERTAIN([Escalated: material uncertainty])
-
+  RECENCY_STATUS -->|TOOLS_MISSING| RECENCY_LIMIT[Set tools-missing limitation flag and keep only supportable freshness claims]
   RECENCY_LIMIT --> CLAIM_SELECT
-  CLAIM_SELECT --> CLAIMS[Dispatch claim-verifier for evidence strength, overstatement, and counterexamples]
-  CLAIMS --> CLAIM_STATUS{CLAIM_REVIEW status?}
+  RECENCY_STATUS -->|ERROR| RECENCY_ERROR{Recency ERROR retry used?}
+  RECENCY_ERROR -->|no| RECENCY_RETRY[Retry ./subagents/recency-checker.md once]
+  RECENCY_RETRY --> RECENCY_STATUS
+  RECENCY_ERROR -->|yes| MATERIAL_UNCERTAINTY([MATERIAL_UNCERTAINTY: recency review unavailable])
+
+  CLAIM_SELECT --> CLAIM_INIT[Dispatch ./subagents/claim-verifier.md initial review]
+  CLAIM_INIT --> CLAIM_STATUS{CLAIM_REVIEW status?}
 
   CLAIM_STATUS -->|PASS| OVERLAP[Apply stricter result where recency and claim reviews overlap]
-  CLAIM_STATUS -->|FAIL| CLAIM_FIX[Apply only claim-verifier flagged edits]
-  CLAIM_STATUS -->|TOOLS_MISSING| CLAIM_LIMIT[Qualify claims by evidence limits and freshness scope]
-  CLAIM_STATUS -->|ERROR| CLAIM_ERROR{Repeated error or repair cap hit?}
+  CLAIM_STATUS -->|FAIL| CLAIM_REPAIR{Claim FAIL reruns used < 2?}
+  CLAIM_REPAIR -->|yes| CLAIM_FIX[Apply only claim-verifier flagged edits]
+  CLAIM_FIX --> CLAIM_RERUN[Targeted rerun of ./subagents/claim-verifier.md]
+  CLAIM_RERUN --> CLAIM_STATUS
+  CLAIM_REPAIR -->|no| NEEDS_REPAIR
 
-  CLAIM_FIX --> CLAIM_CAP{Repair cap reached?}
-  CLAIM_CAP -->|no| CLAIMS
-  CLAIM_CAP -->|yes| CAP_STOP
-
-  CLAIM_ERROR -->|no| CLAIMS
-  CLAIM_ERROR -->|yes| UNCERTAIN
-
+  CLAIM_STATUS -->|TOOLS_MISSING| CLAIM_LIMIT[Set tools-missing limitation flag and qualify evidence strength]
   CLAIM_LIMIT --> OVERLAP
+  CLAIM_STATUS -->|ERROR| CLAIM_ERROR{Claim ERROR retry used?}
+  CLAIM_ERROR -->|no| CLAIM_RETRY[Retry ./subagents/claim-verifier.md once]
+  CLAIM_RETRY --> CLAIM_STATUS
+  CLAIM_ERROR -->|yes| MATERIAL_UNCERTAINTY
+
   OVERLAP --> COMPLETE{Inline completeness check passes?}
-  COMPLETE -->|yes| FINALIZE[Finalize direct user-visible answer]
+  COMPLETE -->|yes| FINAL_WORDING[Prepare final user-visible answer]
   COMPLETE -->|no| COMPLETE_FIX[Add missing qualifiers, scope, or unresolved uncertainty]
-  COMPLETE_FIX --> FINALIZE
+  COMPLETE_FIX --> FINAL_WORDING
 
-  FINALIZE --> OUTPUT{Output condition?}
-  OUTPUT -->|ready| READY([Ready: final answer])
-  OUTPUT -->|tools missing| BLOCKED([Blocked/tools missing: conservative answer])
-  OUTPUT -->|material uncertainty| UNCERTAIN
-  OUTPUT -->|needs repair| NEEDS_REPAIR([Needs repair/rerun])
+  FINAL_WORDING --> NEW_CLAIM_CHECK{Final wording added new current-fact claim?}
+  NEW_CLAIM_CHECK -->|time-sensitive| RECENCY_RERUN
+  NEW_CLAIM_CHECK -->|decision-shaping| CLAIM_RERUN
+  NEW_CLAIM_CHECK -->|both| RECENCY_RERUN
+  NEW_CLAIM_CHECK -->|no| LIMIT_GATE{Limitation flag material?}
 
-  class DATE,DRAFT_CHECK,RECENCY_STATUS,RECENCY_CAP,RECENCY_ERROR,CLAIM_STATUS,CLAIM_CAP,CLAIM_ERROR,COMPLETE,OUTPUT,MUTATION decision;
-  class RISK,RECENCY,CLAIMS,OVERLAP,COMPLETE_FIX check;
-  class SCOPE,RECENCY_FIX,RECENCY_LIMIT,CLAIM_FIX,CLAIM_LIMIT guard;
-  class DRAFT,SET_DATE,FINALIZE output;
+  LIMIT_GATE -->|tools missing and material| BLOCKED_TOOLS_MISSING([BLOCKED_TOOLS_MISSING: conservative answer with tool limits])
+  LIMIT_GATE -->|uncertainty material| MATERIAL_UNCERTAINTY
+  LIMIT_GATE -->|not material| READY([READY: final user-visible answer])
+
+  class DATE,DRAFT_CHECK,MUTATION,RECENCY_STATUS,RECENCY_REPAIR,RECENCY_ERROR,CLAIM_STATUS,CLAIM_REPAIR,CLAIM_ERROR,COMPLETE,NEW_CLAIM_CHECK,LIMIT_GATE decision;
+  class RECENCY_INIT,RECENCY_RERUN,RECENCY_RETRY,CLAIM_INIT,CLAIM_RERUN,CLAIM_RETRY check;
+  class BOUNDARY,RISK,RECENCY_FIX,RECENCY_LIMIT,CLAIM_SELECT,CLAIM_FIX,CLAIM_LIMIT,OVERLAP,COMPLETE_FIX guard;
+  class DRAFT,FINAL_WORDING output;
   class READY success;
-  class NEEDS_REPAIR refine;
-  class CAP_STOP,BLOCKED,UNCERTAIN,OUT_OF_SCOPE stop;
-
-  classDef guard fill:#fff3cd,stroke:#856404,color:#000;
-  classDef check fill:#e7f1ff,stroke:#0b5ed7,color:#000;
-  classDef decision fill:#f8f9fa,stroke:#495057,color:#000;
-  classDef output fill:#e8f5e9,stroke:#2e7d32,color:#000;
-  classDef success fill:#e8f5e9,stroke:#2e7d32,color:#000;
-  classDef refine fill:#fff3cd,stroke:#856404,color:#000;
-  classDef stop fill:#fdecea,stroke:#b02a37,color:#000;
+  class NEEDS_REPAIR,BLOCKED_TOOLS_MISSING,MATERIAL_UNCERTAINTY,OUT_OF_SCOPE stop;
 ```
 
-Readiness rule: Produce the user-visible final answer, not a verification report, unless the user asks for verification details. Include date and scope qualifiers, unresolved material uncertainty, or conservative wording when evidence or tools are limited.
+Readiness rule: Produce the final user-visible answer, not a verification report, unless the user asks for verification details. Include date, freshness scope, evidence limits, unresolved material uncertainty, and conservative wording when evidence or tools are limited.
+
+Deterministic repair rule: Each subagent receives one initial review. A `FAIL` permits at most 2 targeted reruns for that subagent after flagged edits. An `ERROR` permits one retry. Cap exits must resolve to `NEEDS_REPAIR`, `MATERIAL_UNCERTAINTY`, or `BLOCKED_TOOLS_MISSING`, not silent readiness.
+
+New-claim rule: If final wording or completeness repair adds a new time-sensitive claim, rerun `./subagents/recency-checker.md`; if it adds a new decision-shaping claim, rerun `./subagents/claim-verifier.md`; if both, rerun the relevant checks one at a time before finalizing.
 
 Mutation boundary: Any external mutation or high-impact action stays outside Recency Guard and must be routed to a separate approved workflow.

--- a/skills/recency-guard/flow-diagram.md
+++ b/skills/recency-guard/flow-diagram.md
@@ -67,6 +67,15 @@ flowchart TD
   LIMIT_GATE -->|uncertainty material| MATERIAL_UNCERTAINTY
   LIMIT_GATE -->|not material| READY([READY: final user-visible answer])
 
+  classDef guard fill:#fff3cd,stroke:#856404,color:#000;
+  classDef check fill:#e7f1ff,stroke:#0b5ed7,color:#000;
+  classDef decision fill:#f8f9fa,stroke:#495057,color:#000;
+  classDef human fill:#f3e8ff,stroke:#6f42c1,color:#000;
+  classDef output fill:#e8f5e9,stroke:#2e7d32,color:#000;
+  classDef success fill:#e8f5e9,stroke:#2e7d32,color:#000;
+  classDef refine fill:#fff3cd,stroke:#856404,color:#000;
+  classDef stop fill:#fdecea,stroke:#b02a37,color:#000;
+
   class DATE,DRAFT_CHECK,MUTATION,RECENCY_STATUS,RECENCY_REPAIR,RECENCY_ERROR,CLAIM_STATUS,CLAIM_REPAIR,CLAIM_ERROR,COMPLETE,NEW_CLAIM_CHECK,LIMIT_GATE decision;
   class RECENCY_INIT,RECENCY_RERUN,RECENCY_RETRY,CLAIM_INIT,CLAIM_RERUN,CLAIM_RETRY check;
   class BOUNDARY,RISK,RECENCY_FIX,RECENCY_LIMIT,CLAIM_SELECT,CLAIM_FIX,CLAIM_LIMIT,OVERLAP,COMPLETE_FIX guard;

--- a/skills/recency-guard/references/repair-and-integration.md
+++ b/skills/recency-guard/references/repair-and-integration.md
@@ -12,12 +12,17 @@ the latest concise verdict and unresolved risks in orchestrator context.
 | --------------- | ------------------- |
 | `PASS` | Continue to the next phase |
 | `FAIL` | Fix the flagged claims only, then rerun that subagent on the updated draft |
-| `TOOLS_MISSING` | Keep only supportable claims and qualify freshness limits where they affect the answer |
+| `TOOLS_MISSING` | Set a tools-missing limitation flag, keep only supportable claims, and qualify freshness limits where they affect the answer |
 | `ERROR` | Retry once with the same inputs; if it repeats, keep conservative wording and surface material uncertainty |
 
 Run the initial review once, then use at most **2 targeted reruns per
 subagent** for the same draft. If material uncertainty remains after the
 cap, state it plainly in the final answer.
+
+Use `RECENCY_REPAIR` and `CLAIM_REPAIR` as the bounded `FAIL` gates. Use
+`RECENCY_ERROR` and `CLAIM_ERROR` as the one-retry `ERROR` gates. Cap exits
+resolve to `NEEDS_REPAIR`, `MATERIAL_UNCERTAINTY`, or
+`BLOCKED_TOOLS_MISSING`, not silent readiness.
 
 ## Confidence To Wording
 
@@ -43,5 +48,12 @@ apply the corresponding confidence label.
 2. Qualifiers proportional to remaining uncertainty.
 3. Concrete wording preserved where the user must act.
 4. Verification details kept internal unless the user asks.
-5. If the user asks for verification reasoning, summarize the final
+5. Run `NEW_CLAIM_CHECK`: if final wording or completeness repair adds a new
+   time-sensitive claim, rerun `recency-checker`; if it adds a new
+   decision-shaping claim, rerun `claim-verifier`; if it adds both, rerun the
+   relevant checks one at a time.
+6. Run `LIMIT_GATE`: if tools are missing and material, return
+   `BLOCKED_TOOLS_MISSING`; if uncertainty is material, return
+   `MATERIAL_UNCERTAINTY`; otherwise return `READY`.
+7. If the user asks for verification reasoning, summarize the final
    claim-level findings rather than the raw audit trail.


### PR DESCRIPTION
## Summary

Aligns the recency-guard skill with explicit bounded repair gates, a new-claim check, and a limit gate that resolves to named terminal states. The flow diagram and reference docs now match the orchestrator workflow in `SKILL.md`.

## Key Changes

- Document `RECENCY_REPAIR` / `CLAIM_REPAIR` (max 2 FAIL reruns) and `RECENCY_ERROR` / `CLAIM_ERROR` (one retry) in `SKILL.md` and `repair-and-integration.md`
- Add `NEW_CLAIM_CHECK` and `LIMIT_GATE` steps before final output, with terminal states: `READY`, `BLOCKED_TOOLS_MISSING`, `MATERIAL_UNCERTAINTY`, `NEEDS_REPAIR`, `OUT_OF_SCOPE`
- Rewrite `flow-diagram.md` Mermaid chart to reflect repair caps, new-claim reruns, limit gate routing, and updated class styling

## Impact

- Documentation-only change to the recency-guard skill; no runtime or script changes
- No automated tests in this repo for skill definitions
- Solo-project PR with no reviewers requested

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only skill documentation with no runtime, API, or test changes.
> 
> **Overview**
> Documentation-only update to the **recency-guard** skill so the orchestrator workflow is explicit about repair limits, late-stage checks, and how runs must end.
> 
> **`SKILL.md`** splits the pipeline into **Final wording** (`NEW_CLAIM_CHECK`, `LIMIT_GATE`) and **Clarity** (named terminal outcomes). Subagent handling now names **`RECENCY_REPAIR` / `CLAIM_REPAIR`** (at most two targeted reruns on `FAIL`), **`RECENCY_ERROR` / `CLAIM_ERROR`** (one retry on `ERROR`), and **`TOOLS_MISSING`** behavior that sets a tools-missing flag instead of vague “qualify and continue.” Steps 8–9 require rerunning subagents when final edits introduce new claims, then **`LIMIT_GATE`** to **`READY`**, **`BLOCKED_TOOLS_MISSING`**, **`MATERIAL_UNCERTAINTY`**, **`NEEDS_REPAIR`**, or **`OUT_OF_SCOPE`**.
> 
> **`flow-diagram.md`** rewrites the Mermaid flow to match: initial vs rerun dispatches, cap exits to **`NEEDS_REPAIR`**, error paths to **`MATERIAL_UNCERTAINTY`**, post-completeness **`NEW_CLAIM_CHECK`** loops, and **`LIMIT_GATE`** routing (replacing generic “ready/blocked/uncertain” nodes).
> 
> **`repair-and-integration.md`** mirrors the same gate names, states that cap exits must not imply silent readiness, and extends the finalization checklist with **`NEW_CLAIM_CHECK`** and **`LIMIT_GATE`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a1631912508126b86698275c412ee8e75fef736. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->