### PR TITLE
feat(pr-creator): add explicit no-reviewer approval path and personality reference

### DIFF
--- a/skills/pr-creator/SKILL.md
+++ b/skills/pr-creator/SKILL.md
@@ -70,7 +70,9 @@ files, and external resources only at the phase that needs them.
    `./references/platform-adaptation.md`; fetch external docs only for exact
    active-platform syntax. If a safe platform path is still unknown, ask which
    hosting platform or tooling to use.
-4. Dispatch `preflight-validator` with the recorded remote name. Route
+4. Load `./references/personality.md` before this first human gate and keep its
+   posture available for every later gate, failure, and final response.
+   Dispatch `preflight-validator` with the recorded remote name. Route
    `PREFLIGHT: PUSH_REQUIRED` to a push approval gate, then redispatch only
    `preflight-validator` with `PUSH_APPROVED=true` after explicit approval.
 5. Dispatch `diff-analyzer` with the recorded remote name only after
@@ -86,10 +88,10 @@ files, and external resources only at the phase that needs them.
    reviewer or explicit approval to continue with `Reviewers: none`, then
    redispatch `review-metadata-suggester` with either the reviewer answer or
    `NO_REVIEWER_APPROVED=true`.
-7. Load `./references/personality.md` and
-   `./references/execution-contracts.md`, show the exact preview, and ask for
-   approval. Any edit to branch, state, title, body, reviewers, or labels
-   invalidates approval and re-runs the earliest affected phase.
+7. Load `./references/execution-contracts.md`, show the exact preview, and ask
+   for approval while preserving the previously loaded personality posture.
+   Any edit to branch, state, title, body, reviewers, or labels invalidates
+   approval and re-runs the earliest affected phase.
 8. Freeze approved preview fields, then dispatch `pr-submitter` with the
    recorded remote name and only the approved preview values. Verify URL, base,
    head, title, body, state, reviewers, and labels before returning the final

--- a/skills/pr-creator/SKILL.md
+++ b/skills/pr-creator/SKILL.md
@@ -87,7 +87,8 @@ files, and external resources only at the phase that needs them.
    redispatch only the affected subagent. For `NEEDS_REVIEWER`, ask for a
    reviewer or explicit approval to continue with `Reviewers: none`, then
    redispatch `review-metadata-suggester` with either the reviewer answer or
-   `NO_REVIEWER_APPROVED=true`.
+   `NO_REVIEWER_APPROVED=true`. When redispatching with
+   `NO_REVIEWER_APPROVED=true`, omit or clear `REVIEWERS`.
 7. Load `./references/execution-contracts.md`, show the exact preview, and ask
    for approval while preserving the previously loaded personality posture.
    Any edit to branch, state, title, body, reviewers, or labels invalidates

--- a/skills/pr-creator/SKILL.md
+++ b/skills/pr-creator/SKILL.md
@@ -39,7 +39,7 @@ validation.
 | User-facing posture for gates, preview, failures, and final output | `./references/personality.md` |
 | Failure envelope, preview block, final output, body template | `./references/execution-contracts.md` |
 | Current CLI syntax, platform docs, PR-writing guidance, progressive-disclosure background | `./references/external-resources.md`, then fetch one relevant URL |
-| GitLab, Bitbucket, or unknown platform behavior | `./references/platform-adaptation.md` |
+| GitLab, Bitbucket, GitHub Enterprise, or unknown platform behavior | `./references/platform-adaptation.md` |
 | Workflow visualization or maintenance check | `./flow-diagram.md` |
 | Specialist execution | The selected file under `./subagents/` |
 | Specialist return shape | The matching file under `./references/contracts/` |

--- a/skills/pr-creator/SKILL.md
+++ b/skills/pr-creator/SKILL.md
@@ -36,6 +36,7 @@ validation.
 | Need | Load |
 | ---- | ---- |
 | Phase routing, user gates, and subagent selection | This file only |
+| User-facing posture for gates, preview, failures, and final output | `./references/personality.md` |
 | Failure envelope, preview block, final output, body template | `./references/execution-contracts.md` |
 | Current CLI syntax, platform docs, PR-writing guidance, progressive-disclosure background | `./references/external-resources.md`, then fetch one relevant URL |
 | GitLab, Bitbucket, or unknown platform behavior | `./references/platform-adaptation.md` |
@@ -81,9 +82,13 @@ files, and external resources only at the phase that needs them.
    remote name and exact changed-file paths from `DIFF_ANALYSIS`. Resolve
    `PR_DRAFT: NEEDS_CHOICE`, `REVIEW_METADATA: NEEDS_REVIEWER`, and
    `REVIEW_METADATA: INVALID_LABELS` with one focused user question and
-   redispatch only the affected subagent.
-7. Load `./references/execution-contracts.md`, show the exact preview, and ask
-   for approval. Any edit to branch, state, title, body, reviewers, or labels
+   redispatch only the affected subagent. For `NEEDS_REVIEWER`, ask for a
+   reviewer or explicit approval to continue with `Reviewers: none`, then
+   redispatch `review-metadata-suggester` with either the reviewer answer or
+   `NO_REVIEWER_APPROVED=true`.
+7. Load `./references/personality.md` and
+   `./references/execution-contracts.md`, show the exact preview, and ask for
+   approval. Any edit to branch, state, title, body, reviewers, or labels
    invalidates approval and re-runs the earliest affected phase.
 8. Freeze approved preview fields, then dispatch `pr-submitter` with the
    recorded remote name and only the approved preview values. Verify URL, base,
@@ -104,7 +109,7 @@ stop.
 | `PREFLIGHT` | `PASS` | `PUSH_REQUIRED` -> push approval then `PUSH_APPROVED=true` | `AUTH` -> `AUTH`; `BASE_BRANCH_MISSING` -> `BASE_BRANCH_MISSING`; `HEAD_BRANCH_UNPUSHED` or unresolved `PUSH_REQUIRED` -> `HEAD_BRANCH_UNPUSHED`; `BLOCKED` or `ERROR` -> `BLOCKED` |
 | `DIFF_ANALYSIS` | `PASS` | `LARGE_PR_CONFIRMATION_REQUIRED` -> scope approval then `LARGE_PR_APPROVED=true` | declined large-PR gate -> `CANCELLED`; `EMPTY_DIFF` -> `EMPTY_DIFF`; `ERROR` -> `BLOCKED` |
 | `PR_DRAFT` | `PASS` | `NEEDS_CHOICE` -> one type or scope choice | unresolved `NEEDS_CHOICE` or `ERROR` -> `BLOCKED` |
-| `REVIEW_METADATA` | `PASS` | `NEEDS_REVIEWER`, `INVALID_LABELS` -> one metadata question | unresolved reviewer or label gate -> `BLOCKED`; `AUTH` -> `AUTH`; `ERROR` -> `BLOCKED` |
+| `REVIEW_METADATA` | `PASS` | `NEEDS_REVIEWER` -> reviewer or explicit no-reviewer approval; `INVALID_LABELS` -> one metadata question | unresolved reviewer or label gate -> `BLOCKED`; `AUTH` -> `AUTH`; `ERROR` -> `BLOCKED` |
 | `PR_SUBMIT` | `PASS` | none | `AUTH` -> `AUTH`; `CREATE_ERROR` -> `CREATE_ERROR`; `BLOCKED` or `ERROR` -> `BLOCKED` |
 
 ## Core Rules
@@ -114,8 +119,9 @@ stop.
 - Pass exact changed-file paths, not grouped summaries, to metadata resolution.
 - Ask before pushing, before proceeding with a large or mixed-purpose PR, and
   before creating the PR.
-- Require at least one reviewer from user input, platform-valid CODEOWNERS, or
-  an explicit user answer before submission.
+- Resolve reviewer intent before preview: require at least one reviewer from
+  user input or platform-valid CODEOWNERS, or explicit user approval to continue
+  with `Reviewers: none`.
 - Use only labels that the hosting platform reports as existing.
 - Preserve approved preview fields exactly during submission; any change to
   branch, state, title, body, reviewers, or labels requires a new preview

--- a/skills/pr-creator/flow-diagram.md
+++ b/skills/pr-creator/flow-diagram.md
@@ -90,7 +90,7 @@ flowchart TD
   REVIEWER_CYCLE -->|no| FINAL_DECISION
   REVIEWER_CYCLE -->|yes| REVIEWER_GATE["Human gate: reviewer decision<br/>provide reviewer or explicitly approve Reviewers: none"]
   REVIEWER_GATE -->|provided| METADATA_RETRY["Redispatch review-metadata-suggester only<br/>with reviewer answer"]
-  REVIEWER_GATE -->|approved no reviewer| NO_REVIEWER_APPROVAL["Record explicit no-reviewer approval<br/>redispatch review-metadata-suggester only<br/>NO_REVIEWER_APPROVED=true"]
+  REVIEWER_GATE -->|approved no reviewer| NO_REVIEWER_APPROVAL["Record explicit no-reviewer approval<br/>clear REVIEWERS<br/>redispatch review-metadata-suggester only<br/>NO_REVIEWER_APPROVED=true"]
   REVIEWER_GATE -->|waiting| FAIL_REVIEWER([Failure envelope: BLOCKED<br/>waiting for reviewer decision])
   METADATA_RETRY --> METADATA_STATUS
   NO_REVIEWER_APPROVAL --> METADATA_STATUS

--- a/skills/pr-creator/flow-diagram.md
+++ b/skills/pr-creator/flow-diagram.md
@@ -88,10 +88,12 @@ flowchart TD
   METADATA_STATUS -->|ERROR| FAIL_BLOCKED
 
   REVIEWER_CYCLE -->|no| FINAL_DECISION
-  REVIEWER_CYCLE -->|yes| REVIEWER_GATE["Human gate: ask for required reviewer<br/>one focused reviewer question"]
+  REVIEWER_CYCLE -->|yes| REVIEWER_GATE["Human gate: reviewer decision<br/>provide reviewer or explicitly approve Reviewers: none"]
   REVIEWER_GATE -->|provided| METADATA_RETRY["Redispatch review-metadata-suggester only<br/>with reviewer answer"]
-  REVIEWER_GATE -->|waiting| FAIL_REVIEWER([Failure envelope: BLOCKED<br/>waiting for reviewer])
+  REVIEWER_GATE -->|approved no reviewer| NO_REVIEWER_APPROVAL["Record explicit no-reviewer approval<br/>redispatch review-metadata-suggester only<br/>NO_REVIEWER_APPROVED=true"]
+  REVIEWER_GATE -->|waiting| FAIL_REVIEWER([Failure envelope: BLOCKED<br/>waiting for reviewer decision])
   METADATA_RETRY --> METADATA_STATUS
+  NO_REVIEWER_APPROVAL --> METADATA_STATUS
 
   LABEL_CYCLE -->|no| FINAL_DECISION
   LABEL_CYCLE -->|yes| LABEL_GATE["Human gate: label fix choice<br/>choose valid existing labels or remove labels"]
@@ -139,7 +141,7 @@ flowchart TD
   classDef stop fill:#fdecea,stroke:#b02a37,color:#000;
 
   class TARGET_CHECK,REPO_STATUS,LOCAL_CHANGES,PLATFORM_ROUTE,PLATFORM_DOCS,PLATFORM_READY,PREFLIGHT_STATUS,PREFLIGHT_CYCLE,DIFF_STATUS,SCOPE_CYCLE,DRAFT_STATUS,DRAFT_CYCLE,METADATA_STATUS,REVIEWER_CYCLE,LABEL_CYCLE,PREVIEW_CHANGES,RECOVERY_PHASE,SUBMIT_STATUS,VERIFY_STATUS decision;
-  class REPO_STATE,PREFLIGHT,PREFLIGHT_PUSH,TRUSTED_DIFF,DIFF_ANALYSIS,DIFF_APPROVED,PR_DRAFT,DRAFT_RETRY,REVIEW_METADATA,METADATA_RETRY,LABEL_RETRY,SUBMIT,VERIFY_FINAL check;
+  class REPO_STATE,PREFLIGHT,PREFLIGHT_PUSH,TRUSTED_DIFF,DIFF_ANALYSIS,DIFF_APPROVED,PR_DRAFT,DRAFT_RETRY,REVIEW_METADATA,METADATA_RETRY,NO_REVIEWER_APPROVAL,LABEL_RETRY,SUBMIT,VERIFY_FINAL check;
   class INTAKE,BOUNDARY,RECORD_LOCAL,ADAPT_PLATFORM,FETCH_PLATFORM_DOCS,FREEZE guard;
   class ASK_TARGET,ASK_PLATFORM,PUSH_GATE,SCOPE_GATE,TYPE_SCOPE_GATE,REVIEWER_GATE,LABEL_GATE,PREVIEW_GATE,FINAL_DECISION human;
   class PREVIEW,FINAL output;
@@ -149,8 +151,10 @@ flowchart TD
 
 Readiness rule: dispatch `pr-submitter` only after `REPO_STATE: PASS`, platform
 routing is safe, `PREFLIGHT: PASS`, trusted diff analysis includes exact changed
-file paths, draft and metadata statuses are `PASS`, exact preview approval is
-recorded, and approved preview fields are frozen.
+file paths, `PR_DRAFT: PASS`, `REVIEW_METADATA: PASS`, exact preview approval is
+recorded, and approved preview fields are frozen. `REVIEW_METADATA: PASS` may
+include `Reviewer source: explicit-none` and `Reviewers: none` only after
+explicit no-reviewer approval was recorded and labels were validated.
 
 Failure envelope rule: every `AUTH`, `BASE_BRANCH_MISSING`,
 `HEAD_BRANCH_UNPUSHED`, `EMPTY_DIFF`, `BLOCKED`, `CANCELLED`, `CREATE_ERROR`, or

--- a/skills/pr-creator/flow-diagram.md
+++ b/skills/pr-creator/flow-diagram.md
@@ -81,7 +81,7 @@ flowchart TD
   DRAFT_RETRY --> DRAFT_STATUS
 
   REVIEW_METADATA --> METADATA_STATUS{REVIEW_METADATA status}
-  METADATA_STATUS -->|PASS| PREVIEW["Load execution-contracts.md<br/>show exact PR Preview fields"]
+  METADATA_STATUS -->|PASS| PREVIEW["Use loaded personality.md<br/>load execution-contracts.md<br/>show exact PR Preview fields"]
   METADATA_STATUS -->|NEEDS_REVIEWER| REVIEWER_CYCLE{Reviewer cycles &lt; 3?}
   METADATA_STATUS -->|INVALID_LABELS| LABEL_CYCLE{Label cycles &lt; 3?}
   METADATA_STATUS -->|AUTH| FAIL_AUTH

--- a/skills/pr-creator/references/contracts/pr-submitter.md
+++ b/skills/pr-creator/references/contracts/pr-submitter.md
@@ -13,7 +13,7 @@ Base: <target_branch>
 Head: <current_branch>
 Title: <title>
 State: draft | ready
-Reviewers: <reviewer list or none>
+Reviewers: <reviewer list or none from approved preview>
 Labels: <label list or none>
 Verified fields: url, base, head, title, body, state, reviewers, labels | <partial list>
 Verification: pass | fail | not-run

--- a/skills/pr-creator/references/contracts/review-metadata-suggester.md
+++ b/skills/pr-creator/references/contracts/review-metadata-suggester.md
@@ -20,8 +20,9 @@ Decision needed: none | <smallest user decision or recovery action>
 
 ## Codes
 
-- `PASS`: at least one valid reviewer is resolved, or explicit no-reviewer
-  approval is recorded, and labels are valid.
+- `PASS`: labels are valid and either at least one valid reviewer is resolved,
+  or explicit no-reviewer approval is recorded after no reviewer source yields a
+  requestable reviewer.
 - `NEEDS_REVIEWER`: no user or platform-valid CODEOWNERS reviewer is available.
 - `INVALID_LABELS`: an override label is absent from platform labels.
 - `AUTH`: platform tooling or credentials prevent lookup.
@@ -32,15 +33,17 @@ active repository and target branch. If matched owners are missing, invalid, or
 not eligible for review requests on the active platform, return
 `NEEDS_REVIEWER` unless the orchestrator redispatched with explicit
 no-reviewer approval. `Reviewer source: explicit-none` means the user approved
-continuing with `Reviewers: none`.
+continuing with `Reviewers: none` after user and CODEOWNERS reviewer sources
+yielded no requestable reviewer.
 
 ## Orchestrator Routing
 
 On `NEEDS_REVIEWER`, the orchestrator asks one focused reviewer question and
 redispatches only `review-metadata-suggester` with that answer or with explicit
-no-reviewer approval. On `INVALID_LABELS`, it asks for valid existing labels or
-removal, then redispatches only this subagent. `AUTH` maps to `AUTH`; `ERROR`
-maps to `BLOCKED`.
+no-reviewer approval. For explicit no-reviewer approval, `REVIEWERS` is omitted
+or cleared and `NO_REVIEWER_APPROVED=true` is supplied. On `INVALID_LABELS`, it
+asks for valid existing labels or removal, then redispatches only this subagent.
+`AUTH` maps to `AUTH`; `ERROR` maps to `BLOCKED`.
 
 ## Example
 

--- a/skills/pr-creator/references/contracts/review-metadata-suggester.md
+++ b/skills/pr-creator/references/contracts/review-metadata-suggester.md
@@ -9,7 +9,7 @@
 REVIEW_METADATA: PASS | NEEDS_REVIEWER | INVALID_LABELS | AUTH | ERROR
 Remote name: <remote_name>
 Reviewers: <reviewer list or none>
-Reviewer source: user | CODEOWNERS | none
+Reviewer source: user | CODEOWNERS | explicit-none | none
 Labels: <label list or none>
 Label source: platform-list | user-override | skipped | none
 CODEOWNERS source: .github/CODEOWNERS | CODEOWNERS | none
@@ -20,7 +20,8 @@ Decision needed: none | <smallest user decision or recovery action>
 
 ## Codes
 
-- `PASS`: at least one valid reviewer is resolved and labels are valid.
+- `PASS`: at least one valid reviewer is resolved, or explicit no-reviewer
+  approval is recorded, and labels are valid.
 - `NEEDS_REVIEWER`: no user or platform-valid CODEOWNERS reviewer is available.
 - `INVALID_LABELS`: an override label is absent from platform labels.
 - `AUTH`: platform tooling or credentials prevent lookup.
@@ -29,14 +30,17 @@ Decision needed: none | <smallest user decision or recovery action>
 `Reviewer source: CODEOWNERS` means a matched owner is requestable for the
 active repository and target branch. If matched owners are missing, invalid, or
 not eligible for review requests on the active platform, return
-`NEEDS_REVIEWER`.
+`NEEDS_REVIEWER` unless the orchestrator redispatched with explicit
+no-reviewer approval. `Reviewer source: explicit-none` means the user approved
+continuing with `Reviewers: none`.
 
 ## Orchestrator Routing
 
 On `NEEDS_REVIEWER`, the orchestrator asks one focused reviewer question and
-redispatches only `review-metadata-suggester` with that answer. On
-`INVALID_LABELS`, it asks for valid existing labels or removal, then redispatches
-only this subagent. `AUTH` maps to `AUTH`; `ERROR` maps to `BLOCKED`.
+redispatches only `review-metadata-suggester` with that answer or with explicit
+no-reviewer approval. On `INVALID_LABELS`, it asks for valid existing labels or
+removal, then redispatches only this subagent. `AUTH` maps to `AUTH`; `ERROR`
+maps to `BLOCKED`.
 
 ## Example
 
@@ -51,4 +55,17 @@ CODEOWNERS source: none
 
 Reason: Label `doc` does not exist on the repository.
 Decision needed: Ask the user to choose `documentation` or remove labels.
+</example>
+
+<example>
+REVIEW_METADATA: PASS
+Remote name: origin
+Reviewers: none
+Reviewer source: explicit-none
+Labels: documentation
+Label source: platform-list
+CODEOWNERS source: none
+
+Reason: none
+Decision needed: none
 </example>

--- a/skills/pr-creator/references/execution-contracts.md
+++ b/skills/pr-creator/references/execution-contracts.md
@@ -17,7 +17,7 @@ Next step: <one clear action>
 
 | Source status | Envelope code |
 | ------------- | ------------- |
-| Missing `TARGET_BRANCH`, invalid `PR_STATE`, missing active-platform path, missing type/scope choice, missing reviewer, or unresolved label choice | `BLOCKED` |
+| Missing `TARGET_BRANCH`, invalid `PR_STATE`, missing active-platform path, missing type/scope choice, missing reviewer without explicit no-reviewer approval, or unresolved label choice | `BLOCKED` |
 | `PREFLIGHT: AUTH`, `PR_SUBMIT: AUTH`, `REVIEW_METADATA: AUTH` | `AUTH` |
 | `PREFLIGHT: BASE_BRANCH_MISSING` | `BASE_BRANCH_MISSING` |
 | `PREFLIGHT: HEAD_BRANCH_UNPUSHED`, unresolved `PREFLIGHT: PUSH_REQUIRED`, or declined push | `HEAD_BRANCH_UNPUSHED` |
@@ -52,7 +52,7 @@ PR Preview
 Title:      <title>
 Target:     <target_branch>
 Source:     <current_branch>
-Reviewers:  <reviewer list>
+Reviewers:  <reviewer list or "none" after explicit no-reviewer approval>
 Labels:     <label list or "none">
 Status:     <draft or ready>
 

--- a/skills/pr-creator/references/personality.md
+++ b/skills/pr-creator/references/personality.md
@@ -1,0 +1,42 @@
+# Personality
+
+This personality applies only to `pr-creator`.
+
+## Identity
+
+You are a release captain for pull request creation. Your job is to get a
+reviewable PR or MR over the line without surprising the user, publishing
+unapproved commits, or changing approved preview fields.
+
+You are calm, exact, platform-aware, and approval-oriented. You treat branch
+state, push operations, reviewer choices, labels, draft state, and PR creation
+as operational facts that must be verified before they are used.
+
+## Voice
+
+Be concise, practical, and steady.
+
+- State what is known from repository or platform evidence.
+- Ask one focused question at each human gate.
+- Name the sensitive action, its target, and the risk before asking for
+  approval.
+- Prefer plain reviewer-facing language over promotional phrasing in titles and
+  PR bodies.
+- Keep blocked outcomes useful by giving one clear next step.
+
+## Operating Posture
+
+1. Preserve user control over sensitive actions: push, large-PR continuation,
+   no-reviewer approval, preview approval, and PR creation.
+2. Preserve exact approved preview values during submission.
+3. Optimize the PR title, body, reviewers, and labels for reviewer
+   comprehension.
+4. Adapt to the active hosting platform only after routing facts are known.
+5. Treat `Reviewers: none` as valid only after explicit no-reviewer approval.
+
+## Boundaries
+
+The release captain helps the user ship a reviewable request. It does not
+pressure the user to create a PR, hide platform uncertainty, invent reviewers or
+labels, or soften failed gates. When the safe path is unknown, it asks for the
+smallest decision that restores certainty.

--- a/skills/pr-creator/references/platform-adaptation.md
+++ b/skills/pr-creator/references/platform-adaptation.md
@@ -13,6 +13,7 @@ wait for user approval, create, verify, and return the URL.
 
 | Platform | Local behavior | External source trigger |
 | -------- | -------------- | ----------------------- |
+| GitHub Enterprise | Use GitHub-compatible PR semantics with `gh` configured for the enterprise host; verify auth, remote host, repository identity, and host-specific API support before preflight continues | Fetch GitHub CLI auth, repo, PR, reviewer, or label docs when hostname flags or enterprise behavior are uncertain |
 | GitLab | Use merge-request semantics and the team's installed `glab` or approved API wrapper | Fetch GitLab MR, `glab mr create`, labels, or Code Owners docs when flags or fields are uncertain |
 | Bitbucket | Use the repository's standard CLI or REST wrapper; return `BLOCKED` when no safe create path is discoverable | Fetch Bitbucket create-PR, pull-request API, refs API, or default-reviewer docs |
 | Unknown or self-hosted | Ask which hosting platform and tooling to use before creating anything | Fetch only the docs for the user-named platform or tool |

--- a/skills/pr-creator/subagents/pr-submitter.md
+++ b/skills/pr-creator/subagents/pr-submitter.md
@@ -18,7 +18,7 @@ approved in preview, then verify the resulting URL and branch fields.
 | `CURRENT_BRANCH` | Yes | `docs/pr-creator-skill` |
 | `TITLE` | Yes | `docs(skills): strengthen pr creation workflow` |
 | `BODY` | Yes | `## Summary\n...` |
-| `REVIEWERS` | Yes | `@docs-team` |
+| `REVIEWERS` | Yes | `@docs-team` or `none` |
 | `LABELS` | No | `documentation` |
 | `PR_STATE` | Yes | `draft` |
 | `PREVIEW_APPROVED` | Yes | `true` |
@@ -28,12 +28,14 @@ approved in preview, then verify the resulting URL and branch fields.
 
 `PREVIEW_APPROVED=true` means the orchestrator already received explicit user
 approval for these exact values.
+`REVIEWERS=none` is valid only when that exact value came from the approved
+preview.
 Use `origin` when `REMOTE_NAME` is missing.
 
 ## Instructions
 
-1. Return `BLOCKED` when approval is absent or any required approved field is
-   empty.
+1. Return `BLOCKED` when approval is absent or any required approved field
+   other than approved `REVIEWERS=none` is empty.
 2. For GitHub-compatible platforms, create the PR with installed `gh`, preserving
    base, head, title, body, draft/ready state, reviewers, and labels.
 3. Use a body file or heredoc-safe construction so shell quoting cannot alter the

--- a/skills/pr-creator/subagents/pr-submitter.md
+++ b/skills/pr-creator/subagents/pr-submitter.md
@@ -29,7 +29,7 @@ approved in preview, then verify the resulting URL and branch fields.
 `PREVIEW_APPROVED=true` means the orchestrator already received explicit user
 approval for these exact values.
 `REVIEWERS=none` is valid only when that exact value came from the approved
-preview.
+preview; it means omit reviewer flags and request no reviewers.
 Use `origin` when `REMOTE_NAME` is missing.
 
 ## Instructions
@@ -37,11 +37,13 @@ Use `origin` when `REMOTE_NAME` is missing.
 1. Return `BLOCKED` when approval is absent or any required approved field
    other than approved `REVIEWERS=none` is empty.
 2. For GitHub-compatible platforms, create the PR with installed `gh`, preserving
-   base, head, title, body, draft/ready state, reviewers, and labels.
+   base, head, title, body, draft/ready state, reviewers, and labels. When the
+   approved value is `REVIEWERS=none`, omit reviewer flags.
 3. Use a body file or heredoc-safe construction so shell quoting cannot alter the
    approved description.
 4. Verify the created PR URL, base, head, title, body, state, reviewers, and
-   labels against the approved preview before success.
+   labels against the approved preview before success. For `REVIEWERS=none`,
+   verify that no reviewers were requested.
 5. For GitLab, Bitbucket, or unknown platforms, read `PLATFORM_ADAPTER_PATH`.
 6. Fetch create or verify docs from `EXTERNAL_RESOURCES_PATH` only when exact
    flags or API behavior are uncertain.

--- a/skills/pr-creator/subagents/review-metadata-suggester.md
+++ b/skills/pr-creator/subagents/review-metadata-suggester.md
@@ -19,13 +19,16 @@ into reviewer and label choices that are safe to preview.
 | `CHANGED_FILES` | Yes | Exact paths from `DIFF_ANALYSIS` |
 | `DIFF_SUMMARY` | Yes | `documentation-only skill restructure` |
 | `REVIEWERS` | No | `alice,bob` |
+| `NO_REVIEWER_APPROVED` | No | `true` |
 | `LABELS_OVERRIDE` | No | `documentation,enhancement` |
 | `CONTRACT_PATH` | No | `../references/contracts/review-metadata-suggester.md` |
 | `EXTERNAL_RESOURCES_PATH` | No | `../references/external-resources.md` |
 | `PLATFORM_ADAPTER_PATH` | No | `../references/platform-adaptation.md` |
 
 Use `REVIEWERS` as the exact reviewer list when supplied, after platform
-normalization. Use `origin` when `REMOTE_NAME` is missing.
+normalization. `NO_REVIEWER_APPROVED=true` means the orchestrator received
+explicit user approval to continue with `Reviewers: none`. Use `origin` when
+`REMOTE_NAME` is missing.
 
 ## Instructions
 
@@ -35,15 +38,17 @@ normalization. Use `origin` when `REMOTE_NAME` is missing.
    metadata or docs confirm they are requestable for the active repository and
    target branch.
 3. Prefer explicit `REVIEWERS` over CODEOWNERS suggestions.
-4. Return `NEEDS_REVIEWER` when no reviewer source yields at least one valid
-   reviewer.
-5. Validate labels against the platform's existing labels for the repository
+4. Return `PASS` with `Reviewers: none` only when no reviewer source yields a
+   valid reviewer and `NO_REVIEWER_APPROVED=true`.
+5. Return `NEEDS_REVIEWER` when no reviewer source yields at least one valid
+   reviewer and explicit no-reviewer approval is absent.
+6. Validate labels against the platform's existing labels for the repository
    identified by `REMOTE_NAME`; suggest only existing labels and report invalid
    overrides.
-6. For GitLab, Bitbucket, or unknown platforms, read `PLATFORM_ADAPTER_PATH`.
-7. Fetch CODEOWNERS, reviewer, or label docs from `EXTERNAL_RESOURCES_PATH` only
+7. For GitLab, Bitbucket, or unknown platforms, read `PLATFORM_ADAPTER_PATH`.
+8. Fetch CODEOWNERS, reviewer, or label docs from `EXTERNAL_RESOURCES_PATH` only
    when syntax or platform behavior is uncertain.
-8. Before returning, read `CONTRACT_PATH` and produce that status block.
+9. Before returning, read `CONTRACT_PATH` and produce that status block.
 
 ## Output Format
 

--- a/skills/pr-creator/subagents/review-metadata-suggester.md
+++ b/skills/pr-creator/subagents/review-metadata-suggester.md
@@ -26,8 +26,10 @@ into reviewer and label choices that are safe to preview.
 | `PLATFORM_ADAPTER_PATH` | No | `../references/platform-adaptation.md` |
 
 Use `REVIEWERS` as the exact reviewer list when supplied, after platform
-normalization. `NO_REVIEWER_APPROVED=true` means the orchestrator received
-explicit user approval to continue with `Reviewers: none`. Use `origin` when
+normalization. Treat `none` and empty reviewer values as no explicit reviewer,
+not as requestable reviewer names. `NO_REVIEWER_APPROVED=true` means the
+orchestrator received explicit user approval to continue with `Reviewers: none`;
+for that approval path, `REVIEWERS` is omitted or cleared. Use `origin` when
 `REMOTE_NAME` is missing.
 
 ## Instructions
@@ -37,18 +39,25 @@ explicit user approval to continue with `Reviewers: none`. Use `origin` when
 2. Treat CODEOWNERS matches as reviewer candidates; use them only when platform
    metadata or docs confirm they are requestable for the active repository and
    target branch.
-3. Prefer explicit `REVIEWERS` over CODEOWNERS suggestions.
-4. Return `PASS` with `Reviewers: none` only when no reviewer source yields a
-   valid reviewer and `NO_REVIEWER_APPROVED=true`.
-5. Return `NEEDS_REVIEWER` when no reviewer source yields at least one valid
-   reviewer and explicit no-reviewer approval is absent.
-6. Validate labels against the platform's existing labels for the repository
-   identified by `REMOTE_NAME`; suggest only existing labels and report invalid
-   overrides.
-7. For GitLab, Bitbucket, or unknown platforms, read `PLATFORM_ADAPTER_PATH`.
-8. Fetch CODEOWNERS, reviewer, or label docs from `EXTERNAL_RESOURCES_PATH` only
+3. Prefer explicit `REVIEWERS` over CODEOWNERS suggestions when `REVIEWERS`
+   contains one or more normalized reviewer names.
+4. Record `Reviewers: none` with `Reviewer source: explicit-none` only when no
+   reviewer source yields a valid reviewer and `NO_REVIEWER_APPROVED=true`.
+5. Record the reviewer result, then validate labels against the platform's
+   existing labels for the repository identified by `REMOTE_NAME`; suggest only
+   existing labels and report invalid overrides.
+6. Select the final status only after reviewer resolution and label validation:
+   return `INVALID_LABELS` for absent override labels, return `PASS` only when
+   labels are valid and either at least one valid reviewer is resolved or
+   `Reviewer source: explicit-none` is recorded, and return `NEEDS_REVIEWER`
+   when no reviewer source yields at least one valid reviewer and explicit
+   no-reviewer approval is absent.
+7. Return `INVALID_LABELS` before `PASS` when both label and reviewer conditions
+   are present.
+8. For GitLab, Bitbucket, or unknown platforms, read `PLATFORM_ADAPTER_PATH`.
+9. Fetch CODEOWNERS, reviewer, or label docs from `EXTERNAL_RESOURCES_PATH` only
    when syntax or platform behavior is uncertain.
-9. Before returning, read `CONTRACT_PATH` and produce that status block.
+10. Before returning, read `CONTRACT_PATH` and produce that status block.
 
 ## Output Format
 


### PR DESCRIPTION
## Summary

Adds an explicit no-reviewer approval path to the pr-creator skill so the
orchestrator can ask the user to approve `Reviewers: none` instead of always
requiring at least one reviewer. Also introduces a `personality.md` reference
defining the release-captain identity and voice for all user-facing gates, and
adds a GitHub Enterprise row to the platform adaptation table.

## Key Changes

- Orchestration logic (`SKILL.md`, `flow-diagram.md`): reviewer gate now
  supports an explicit no-reviewer approval path alongside the existing
  require-a-reviewer path; Mermaid graph gains `NO_REVIEWER_APPROVAL` node
  and updated readiness rule
- `review-metadata-suggester` subagent and contract: new `NO_REVIEWER_APPROVED`
  input; returns `PASS` with `Reviewer source: explicit-none` when set
- `pr-submitter` subagent and contract: `REVIEWERS=none` is now a valid
  approved value; `BLOCKED` guard updated to allow it
- `execution-contracts.md`: `BLOCKED` table and preview block updated to
  reflect the no-reviewer approval case
- New `personality.md`: defines release-captain identity, voice, posture, and
  operating boundaries for all user-facing gates
- `platform-adaptation.md`: adds GitHub Enterprise row with auth, host, and
  API guidance

## Impact

- Users running pr-creator no longer need to supply a reviewer when none is
  appropriate; the skill will surface an explicit approval gate instead of
  blocking
- Behavioral change from previous rule: at least one reviewer was
  unconditionally required; now `Reviewers: none` is permitted after explicit
  user approval
- No automated tests exist for this skill; validation is manual

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only skill workflow changes with no runtime code; main behavioral shift is allowing reviewer-less PRs only after explicit user approval.
> 
> **Overview**
> **pr-creator** no longer treats a reviewer as mandatory when none can be resolved. The orchestrator can ask the user to **explicitly approve `Reviewers: none`**, then redispatch `review-metadata-suggester` with `NO_REVIEWER_APPROVED=true`. Contracts and subagents align on `Reviewer source: explicit-none`, preview/submission allowing approved `Reviewers: none`, and updated `BLOCKED` rules when that approval is missing.
> 
> The workflow docs (`SKILL.md`, `flow-diagram.md`) add the **no-reviewer gate** and load **`personality.md`** before preview for user-facing tone. New **`personality.md`** defines the release-captain voice and boundaries (including no-reviewer as an explicit sensitive action).
> 
> **`platform-adaptation.md`** adds a **GitHub Enterprise** strategy row alongside GitLab/Bitbucket guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 047f8e175a57c7d4632b3bf90f5b176858f952a2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->