### PR TITLE
docs(improve-skill-definition): align personality as operating behavior posture

### DIFF
--- a/skills/improve-skill-definition/SKILL.md
+++ b/skills/improve-skill-definition/SKILL.md
@@ -277,7 +277,7 @@ user that the workflow is badly designed.
   `MUTATION_LIMITS`.
 - Target package artifacts align with the approved flow and personality
   contracts, including the personality's operating behavior and decision
-  posture.
+  habits.
 - Subagents remain justified, distinct, and non-overlapping; unnecessary
   subagents are recommended for removal or merge.
 - Validation results are concrete, falsifiable, and tied to approved gaps.

--- a/skills/improve-skill-definition/SKILL.md
+++ b/skills/improve-skill-definition/SKILL.md
@@ -60,11 +60,15 @@ Load `./references/personality.md` before audit. This file defines the
 personality and identity of this skill only.
 
 For every non-trivial target skill, audit personality as part of the operating
-contract:
+contract. A target personality defines how the agent operates: what it notices,
+how it reasons about the work, what it treats as risky, how it validates, when
+it escalates, and how it communicates those decisions. It is not merely a
+user-facing tone layer.
 
 - If `references/personality.md` exists in the target package, summarize it and
-  validate purpose fit, audience fit, tone safety, workflow fit, and consistency
-  with `SKILL.md`, `flow-diagram.md`, subagents, and references.
+  validate purpose fit, audience fit, tone safety, workflow fit, operating
+  behavior fit, and consistency with `SKILL.md`, `flow-diagram.md`, subagents,
+  and references.
 - If it is missing, decide whether personality is `NOT_APPLICABLE` or
   `MISSING_BUT_RECOMMENDED`.
 - Always provide at least five target-specific personality recommendations in
@@ -272,7 +276,8 @@ user that the workflow is badly designed.
 - Edits happen only for approved gaps and stay inside `SCOPE_LIMITS` and
   `MUTATION_LIMITS`.
 - Target package artifacts align with the approved flow and personality
-  contracts.
+  contracts, including the personality's operating behavior and decision
+  posture.
 - Subagents remain justified, distinct, and non-overlapping; unnecessary
   subagents are recommended for removal or merge.
 - Validation results are concrete, falsifiable, and tied to approved gaps.

--- a/skills/improve-skill-definition/references/authoring-checklist.md
+++ b/skills/improve-skill-definition/references/authoring-checklist.md
@@ -20,7 +20,7 @@ reshuffle, or polish content without changing behavior.
 | Skill body | `SKILL.md` is under 500 lines and limited to identity, inputs, outputs, routing, workflow, validation, and a concise example |
 | Flow contract | `flow-diagram.md` is loaded as the source of truth when the skill has multi-phase, gated, or subagent-heavy behavior; semantic diagram changes are routed through `generate-flow-diagram` and accepted only after `REVIEW: PASS` |
 | Flow coherence | `SKILL.md`, subagents, references, scripts, and templates use the same phases, gates, statuses, artifact paths, and subagent names as the approved flow diagram |
-| Personality | Non-trivial skills either define `references/personality.md` or explicitly justify `NOT_APPLICABLE`; personality fits the skill purpose, audience, workflow, and artifact contracts |
+| Personality | Non-trivial skills either define `references/personality.md` or explicitly justify `NOT_APPLICABLE`; personality fits the skill purpose, audience, workflow, operating behavior, and artifact contracts |
 | Paths | Bundled paths are relative to the file that names them, exist on disk, and stay inside the skill package |
 | Mutation boundaries | Planned or completed edits stay inside user `SCOPE_LIMITS` and orchestrator `MUTATION_LIMITS`; broader sync or lockfile work is reported as blocked unless explicitly in scope |
 | Standalone package | Runtime behavior does not depend on repository-local docs, absolute paths, private config, sibling skills, or unavailable files |
@@ -38,7 +38,7 @@ reshuffle, or polish content without changing behavior.
 | `SKILL.md` | The orchestrator needs it for every run: identity, inputs, registry, routing, core workflow, and success criteria |
 | `flow-diagram.md` | The deterministic execution flow, phases, gates, statuses, authority changes, and terminal states |
 | `references/` | Content is static, detailed, template-like, example-heavy, source-backed, or needed only in one phase |
-| `references/personality.md` | The skill's identity, operating posture, tone boundaries, and user-facing critique style |
+| `references/personality.md` | The skill's identity, operating posture, decision habits, validation bias, escalation style, communication style, and tone boundaries |
 | `subagents/` | Work is self-contained and the orchestrator only needs a concise summary, verdict, path, or artifact |
 | `scripts/` | Deterministic parsing, validation, or transformation is safer as executable code than prose |
 
@@ -49,8 +49,8 @@ reshuffle, or polish content without changing behavior.
 - Would deleting the proposed change make future runs worse?
 - Does the current or proposed flow diagram actually govern execution, or is it
   decorative documentation?
-- Does the personality make the skill more coherent for its purpose, or is it
-  just tone cosplay?
+- Does the personality change how the agent investigates, decides, validates,
+  and escalates for this skill's purpose, or is it just tone cosplay?
 - Does each subagent return something the orchestrator needs only as a bounded
   verdict or summary?
 - Is the content being moved genuinely just-in-time, or is it only being moved

--- a/skills/improve-skill-definition/references/final-report-template.md
+++ b/skills/improve-skill-definition/references/final-report-template.md
@@ -20,7 +20,7 @@ Flow diagram verdict:
 Personality assessment:
 - Summary: [current target personality or missing]
 - `PERSONALITY_VERDICT`: `FITS_PURPOSE` | `NEEDS_REFINEMENT` | `MISSING_BUT_RECOMMENDED` | `NOT_APPLICABLE` | `CONFLICTS_WITH_SKILL`
-- Checks run: [purpose fit, audience fit, tone safety, workflow fit, artifact consistency]
+- Checks run: [purpose fit, audience fit, tone safety, workflow fit, operating behavior fit, artifact consistency]
 - Recommendation: [keep, refine, replace, add, or skip]
 - Alternatives: [at least five target-specific options]
 

--- a/skills/improve-skill-definition/references/personality.md
+++ b/skills/improve-skill-definition/references/personality.md
@@ -1,7 +1,8 @@
 # Personality
 
-Read this file before audit and before composing any user-facing assessment.
-This personality applies only to `improve-skill-definition`.
+Read this file before audit and before applying this skill's operating posture
+to any assessment. This personality applies only to
+`improve-skill-definition`.
 
 ## Identity
 
@@ -65,8 +66,9 @@ When evaluating a target skill's personality, report:
 - `PERSONALITY_VERDICT`: `FITS_PURPOSE`, `NEEDS_REFINEMENT`,
   `MISSING_BUT_RECOMMENDED`, `NOT_APPLICABLE`, or `CONFLICTS_WITH_SKILL`.
 - Checks run: purpose fit, audience fit, tone safety, workflow fit,
-  consistency with `SKILL.md`, consistency with `flow-diagram.md`, consistency
-  with subagents, and consistency with references/templates.
+  operating behavior fit, consistency with `SKILL.md`, consistency with
+  `flow-diagram.md`, consistency with subagents, and consistency with
+  references/templates.
 - Recommendation: keep, refine, replace, add, or skip.
 - At least five personality alternatives tailored to the target skill.
 - One explicit user choice: keep current personality or choose a change.

--- a/skills/improve-skill-definition/subagents/skill-definition-editor.md
+++ b/skills/improve-skill-definition/subagents/skill-definition-editor.md
@@ -52,8 +52,10 @@ bundled paths from the improvement skill package root, not from the target
    may support rationale, but normal execution cannot depend on fetching them.
 8. Create or update `references/personality.md` only according to the approved
    personality decision. Align `SKILL.md`, subagents, and references to that
-   personality where it affects behavior, verdict language, escalation style,
-   or output expectations.
+   personality where it affects operating behavior: how the target agent
+   investigates, decides, prioritizes risks, validates, escalates, and
+   communicates. Align verdict language and output expectations only where they
+   express that operating behavior.
 9. Treat target `flow-diagram.md` as the workflow source of truth when present.
    Sync `SKILL.md`, subagents, references, scripts, and templates to the
    approved flow vocabulary.

--- a/skills/improve-skill-definition/subagents/skill-package-auditor.md
+++ b/skills/improve-skill-definition/subagents/skill-package-auditor.md
@@ -61,8 +61,11 @@ rationale changes the verdict.
    `NOT_APPLICABLE`, or `CONFLICTS_WITH_SKILL`.
 6. For personality, summarize the current target personality when present and
    run checks for purpose fit, audience fit, tone safety, workflow fit,
-   consistency with `SKILL.md`, consistency with `flow-diagram.md`, consistency
-   with subagents, and consistency with references/templates.
+   operating behavior fit, consistency with `SKILL.md`, consistency with
+   `flow-diagram.md`, consistency with subagents, and consistency with
+   references/templates. Treat personality as the target agent's operating
+   posture: how it investigates, reasons, prioritizes risks, validates,
+   escalates, and communicates. Do not reduce it to user-facing wording.
 7. Provide at least five personality recommendations tailored to the target
    skill, even when recommending that the current personality be kept.
 8. Classify each observation as `gap`, `optional_improvement`, or `no_op`.
@@ -174,7 +177,7 @@ AUDIT: APPROVAL_REQUIRED
 ## Personality Assessment
 - Current personality summary: missing
 - `PERSONALITY_VERDICT`: MISSING_BUT_RECOMMENDED
-- Checks run: purpose fit, audience fit, tone safety, workflow fit, artifact consistency
+- Checks run: purpose fit, audience fit, tone safety, workflow fit, operating behavior fit, artifact consistency
 - Recommendation: add a skeptical reviewer personality
 - Five personality alternatives: skeptical reviewer, calm educator, strict compliance auditor, pragmatic maintainer, concise release captain
 ```

--- a/skills/improve-skill-definition/subagents/skill-package-validator.md
+++ b/skills/improve-skill-definition/subagents/skill-package-validator.md
@@ -59,8 +59,8 @@ counts.
 10. Confirm personality consistency: the approved personality decision is
     reflected in `references/personality.md` or explicitly skipped as
     `NOT_APPLICABLE`; `SKILL.md`, subagents, references, and templates do not
-    contradict its operating posture, decision habits, validation behavior,
-    escalation style, or communication style.
+    contradict the approved personality's operating posture, decision habits,
+    validation behavior, escalation style, or communication style.
 11. Confirm subagents are justified, distinct, non-overlapping, and covered by
     explicit inputs, instructions, output format, scope, and escalation
     behavior.

--- a/skills/improve-skill-definition/subagents/skill-package-validator.md
+++ b/skills/improve-skill-definition/subagents/skill-package-validator.md
@@ -59,7 +59,8 @@ counts.
 10. Confirm personality consistency: the approved personality decision is
     reflected in `references/personality.md` or explicitly skipped as
     `NOT_APPLICABLE`; `SKILL.md`, subagents, references, and templates do not
-    contradict it.
+    contradict its operating posture, decision habits, validation behavior,
+    escalation style, or communication style.
 11. Confirm subagents are justified, distinct, non-overlapping, and covered by
     explicit inputs, instructions, output format, scope, and escalation
     behavior.


### PR DESCRIPTION
## Summary

Reframes the `improve-skill-definition` skill's personality contract from a tone layer into an operating posture — how the agent investigates, decides, validates, escalates, and communicates. Aligns the orchestrator, checklist, report template, and subagents on a shared "operating behavior fit" audit dimension.

## Key Changes

- Define personality in `SKILL.md` as operating posture (not merely user-facing tone)
- Add "operating behavior fit" to personality audit checks across orchestrator, checklist, and final report template
- Update `skill-package-auditor`, `skill-definition-editor`, and `skill-package-validator` to evaluate and enforce operating behavior consistency
- Expand `references/personality.md` scope to cover decision habits, validation bias, and escalation style

## Impact

- Audits of target skills will now flag personality gaps that affect agent behavior, not just wording
- No runtime or script changes; documentation-only skill package update
- Vendored mirrors under `.agents/skills/` are not updated in this branch (local uncommitted changes exist separately)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to the `improve-skill-definition` skill package; no runtime, scripts, or security-sensitive code paths change.
> 
> **Overview**
> **Personality is now defined as operating posture**, not just user-facing tone. The orchestrator (`SKILL.md`) states that target `references/personality.md` should shape how the agent notices issues, reasons, treats risk, validates, escalates, and communicates—and adds **operating behavior fit** alongside existing personality audit dimensions.
> 
> The same framing propagates through the **authoring checklist**, **final report template**, and **orchestrator personality reference**, including expanded guidance for what belongs in `references/personality.md` and a decision test that rejects “tone cosplay” without behavioral impact.
> 
> **Subagent contracts** are aligned: the auditor must evaluate personality as investigation/decision/validation posture; the editor must sync package artifacts to that behavior (not only wording); the validator must fail inconsistencies in operating posture, decision habits, validation, escalation, and communication style.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afe5edeedd15b1ba8525c630811f34d2b813d559. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->